### PR TITLE
feat: add ETag support SDKCF-1088

### DIFF
--- a/RRemoteConfig/APIClient.swift
+++ b/RRemoteConfig/APIClient.swift
@@ -13,7 +13,7 @@ extension URLSession: SessionProtocol {
 internal class APIClient {
     let session: SessionProtocol
 
-    init(session: SessionProtocol = URLSession.shared) {
+    init(session: SessionProtocol = URLSession(configuration: URLSessionConfiguration.default)) {
         self.session = session
     }
 

--- a/RRemoteConfig/ConfigCache.swift
+++ b/RRemoteConfig/ConfigCache.swift
@@ -45,22 +45,24 @@ internal class ConfigCache {
 
     func refreshFromRemote() {
         self.poller.start {
-            self.fetcher.fetchConfig { (result) in
-                guard let configModel = result else {
-                    return Logger.e("Config could not be refreshed from remote")
-                }
-                self.verifyContents(model: configModel, resultHandler: { (verified) in
-                    if verified {
-                        let dictionary = [
-                            "config": configModel.config,
-                            "keyId": configModel.keyId as Any,
-                            "signature": configModel.signature as Any
-                        ]
-                        self.write(dictionary)
-                    } else {
-                        Logger.e("Fetched dictionary contents failed verification")
+            DispatchQueue.global(qos: .utility).async {
+                self.fetcher.fetchConfig { (result) in
+                    guard let configModel = result else {
+                        return print("Config could not be refreshed from remote")
                     }
-                })
+                    self.verifyContents(model: configModel, resultHandler: { (verified) in
+                        if verified {
+                            let dictionary = [
+                                "config": configModel.config,
+                                "keyId": configModel.keyId as Any,
+                                "signature": configModel.signature as Any
+                            ]
+                            self.write(dictionary)
+                        } else {
+                            Logger.e("Fetched dictionary contents failed verification")
+                        }
+                    })
+                }
             }
         }
     }

--- a/RRemoteConfig/Environment.swift
+++ b/RRemoteConfig/Environment.swift
@@ -9,6 +9,7 @@ internal protocol EnvironmentSetupProtocol {
 
 internal class Environment {
     let bundle: EnvironmentSetupProtocol
+    static let etagKey = "com.rakuten.tech.RemoteConfig.payloadETag"
     private var baseUrl: URL? {
         guard let endpointUrlString = bundle.value(for: "RRCConfigAPIEndpoint") else {
             Logger.e("Ensure RRCConfigAPIEndpoint value in plist is valid")
@@ -46,6 +47,14 @@ internal class Environment {
     }
     var sdkVersion: String {
         return bundle.sdkVersion()
+    }
+    var etag: String? {
+        get {
+            return UserDefaults.standard.string(forKey: Environment.etagKey)
+        }
+        set {
+            UserDefaults.standard.set(newValue, forKey: Environment.etagKey)
+        }
     }
 
     init(bundle: EnvironmentSetupProtocol = Bundle.main) {

--- a/RRemoteConfig/Fetcher.swift
+++ b/RRemoteConfig/Fetcher.swift
@@ -13,14 +13,14 @@ internal class Fetcher {
             return completionHandler(nil)
         }
         var request = URLRequest(url: url)
-        request.addHeader("apiKey", "ras-\(environment.subscriptionKey)")
-        request.setExtraHeaders(from: environment)
+        request.setConfigHeaders(from: environment)
 
         apiClient.send(request: request, decodeAs: ConfigModel.self) { (result, response) in
             switch result {
             case .success(let resultConfig):
                 var config = resultConfig as? ConfigModel
                 config?.signature = response?.allHeaderFields["Signature"] as? String
+                self.environment.etag = response?.allHeaderFields["Etag"] as? String
                 completionHandler(config)
             case .failure(let error):
                 Logger.e("Config fetch url \(String(describing: request.url)) received error \(error.localizedDescription) for response \(String(describing: response))")

--- a/RRemoteConfig/URLRequest+Headers.swift
+++ b/RRemoteConfig/URLRequest+Headers.swift
@@ -1,17 +1,25 @@
 extension URLRequest {
-    mutating func setExtraHeaders(from environment: Environment) {
-        self.addHeader("ras-app-id", environment.appId)
-        self.addHeader("ras-device-model", environment.deviceModel)
-        self.addHeader("ras-device-version", environment.deviceOsVersion)
-        self.addHeader("ras-sdk-name", environment.sdkName)
-        self.addHeader("ras-sdk-version", environment.sdkVersion)
-        self.addHeader("ras-app-name", environment.appName)
-        self.addHeader("ras-app-version", environment.appVersion)
+    mutating func setConfigHeaders(from environment: Environment) {
+        addHeader("ras-app-id", environment.appId)
+        addHeader("ras-device-model", environment.deviceModel)
+        addHeader("ras-device-version", environment.deviceOsVersion)
+        addHeader("ras-sdk-name", environment.sdkName)
+        addHeader("ras-sdk-version", environment.sdkVersion)
+        addHeader("ras-app-name", environment.appName)
+        addHeader("ras-app-version", environment.appVersion)
+        addHeader("apiKey", "ras-\(environment.subscriptionKey)")
+
+        // If the ETag of the requested server config matches this header
+        // the server will respond with 304 Not Modified and the OS will
+        // give us the cached response
+        if let etag = environment.etag {
+            addHeader("If-None-Match", etag)
+        }
     }
 
     mutating func addHeader(_ name: String, _ value: String) {
         if value.count > 0 {
-            self.addValue(value, forHTTPHeaderField: name)
+            addValue(value, forHTTPHeaderField: name)
         }
     }
 }

--- a/Tests/Unit/ConfigCacheTests.swift
+++ b/Tests/Unit/ConfigCacheTests.swift
@@ -244,7 +244,7 @@ class ConfigCacheSpec: QuickSpec {
                 fetcher.fetchConfigCalledNumTimes = 0
                 configCache.refreshFromRemote()
 
-                expect(fetcher.fetchConfigCalledNumTimes).to(equal(1))
+                expect(fetcher.fetchConfigCalledNumTimes).toEventually(equal(1))
             }
 
             describe("when the verification key is found locally") {
@@ -301,7 +301,7 @@ class ConfigCacheSpec: QuickSpec {
                 it("calls the fetch key function") {
                     configCache.refreshFromRemote()
 
-                    expect(fetcher.fetchKeyCalledNumTimes).to(equal(1))
+                    expect(fetcher.fetchKeyCalledNumTimes).toEventually(equal(1))
                 }
 
                 it("adds the key after fetching it") {

--- a/Tests/Unit/TestHelpers.swift
+++ b/Tests/Unit/TestHelpers.swift
@@ -101,6 +101,22 @@ class KeyStoreMock: KeyStore {
     }
 }
 
+class APIClientMock: APIClient {
+    var dictionary: [String: String]?
+    var headers: [String: String]?
+    var error: Error?
+    var request: URLRequest?
+    override func send<T>(request: URLRequest, decodeAs: T.Type, completionHandler: @escaping (Result<Any, Error>, HTTPURLResponse?) -> Void) where T: Decodable {
+        self.request = request
+
+        guard let dictionary = dictionary else {
+            return completionHandler(.failure(error ?? NSError(domain: "Test", code: 0, userInfo: nil)), nil)
+        }
+        let response = HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: "1.1", headerFields: headers)
+        return completionHandler(.success(ConfigModel(config: dictionary)), response)
+    }
+}
+
 func createCacheMock(initialContents: [String: String] = ["": ""]) -> CacheMock {
     return CacheMock(fetcher: Fetcher(client: APIClient(), environment: Environment()), poller: Poller(), initialCacheContents: initialContents)
 }


### PR DESCRIPTION
# Description
- support ETag header and add tests
- fetch the config from a background queue
- create our own session instead of using shared session

## Links
SDKCF-1088

# Checklist
- [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [x] I wrote/updated tests for new/changed code
- [x] I ran `fastlane ci` without errors
