### PR TITLE
docs: add documentation publishing to travis config SDKCF-1084

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,3 +9,17 @@ before_install:
 - pod repo update
 
 script: fastlane ci
+
+after_success:
+  # generate docs
+- gem install jazzy
+- jazzy --xcodebuild-arguments -scheme,Tests --module RRemoteConfig --source-directory RRemoteConfig --podspec RRemoteConfig.podspec --exclude RRemoteConfig/Loader.swift --readme README.md
+
+deploy:
+  provider: pages
+  skip_cleanup: true
+  github_token: $GITHUB_TOKEN
+  keep_history: true
+  local_dir: docs
+  on:
+    branch: master


### PR DESCRIPTION
# Description
Add documentation publishing to travis config. 

When code is pushed to master the generated documentation will be deployed to the gh-pages branch and can be viewed at https://rakutentech.github.io/ios-remote-config/

## Links
SDKCF-1084

# Checklist
- [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [x] I wrote/updated tests for new/changed code
- [x] I ran `fastlane ci` without errors
