### PR TITLE
feat: cache and verify against the response payload data

### DIFF
--- a/RRemoteConfig.xcodeproj/project.pbxproj
+++ b/RRemoteConfig.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		5250CF0315F00518AF2B7A7B /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = C9C9862DDDEEB8A1DAAF4A40 /* Assets.xcassets */; };
 		58553E7B8B303B68C33F79D6 /* FunctionalTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF48B14075CAE45D72E1AB89 /* FunctionalTests.swift */; };
 		5F572A4DB47E22B2C9D9C47A /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F6A780C502D648F776FF2F32 /* Foundation.framework */; };
+		6D1A1254231124EA004BBD77 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D1A1253231124EA004BBD77 /* AppDelegate.swift */; };
 		6D307D2122E9BCAD00D4E115 /* VerifierTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D307D2022E9BCAD00D4E115 /* VerifierTests.swift */; };
 		6D307D2322E9BD6100D4E115 /* KeyStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D307D2222E9BD6100D4E115 /* KeyStoreTests.swift */; };
 		6D307D2422E9BF1E00D4E115 /* KeyStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D307D2222E9BD6100D4E115 /* KeyStoreTests.swift */; };
@@ -51,6 +52,27 @@
 			remoteGlobalIDString = F1FF84343DDC8BEF2A5AD7A5;
 			remoteInfo = SampleApp;
 		};
+		6D1A1263231126C2004BBD77 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = B32C06207C007144B4D259CF /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 6D1A1250231124EA004BBD77;
+			remoteInfo = TestHostRC;
+		};
+		6D1A126523113EE5004BBD77 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = B32C06207C007144B4D259CF /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 6D1A1250231124EA004BBD77;
+			remoteInfo = TestHostRC;
+		};
+		6D1A126723114124004BBD77 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = B32C06207C007144B4D259CF /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 6D1A1250231124EA004BBD77;
+			remoteInfo = TestHostRC;
+		};
 		7F0082C6A2FC3DDEA06DD743 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = B32C06207C007144B4D259CF /* Project object */;
@@ -72,6 +94,9 @@
 		19982D0FEBA288B67DF40F7F /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS12.0.sdk/System/Library/Frameworks/UIKit.framework; sourceTree = DEVELOPER_DIR; };
 		3115B54847398B5D1FFDF8DD /* UnitTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = UnitTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		3A4FFAF6091C4DAAA9F8549C /* Main.storyboard */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = file.storyboard; name = Main.storyboard; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
+		6D1A1251231124EA004BBD77 /* TestHostRC.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = TestHostRC.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		6D1A1253231124EA004BBD77 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		6D1A125F231124EB004BBD77 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		6D307D2022E9BCAD00D4E115 /* VerifierTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VerifierTests.swift; sourceTree = "<group>"; };
 		6D307D2222E9BD6100D4E115 /* KeyStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyStoreTests.swift; sourceTree = "<group>"; };
 		6D622B1722BA243D001FD625 /* APIClientTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIClientTests.swift; sourceTree = "<group>"; };
@@ -81,7 +106,7 @@
 		6D622B2322BB1271001FD625 /* ConfigCacheTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfigCacheTests.swift; sourceTree = "<group>"; };
 		6DBD474722DD716F00AA21CD /* TestHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestHelpers.swift; sourceTree = "<group>"; };
 		904EAA9F750B684EFBA9CC89 /* AppDelegate.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
-		921F4A6AA596AA8B63280A1F /* SampleApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = SampleApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		921F4A6AA596AA8B63280A1F /* RemoteConfig Sample.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "RemoteConfig Sample.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		C9C9862DDDEEB8A1DAAF4A40 /* Assets.xcassets */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		CABEA84D5E02C4936A35AE92 /* Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = Tests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		D7E5BFAE6E9A5A116B70E808 /* LaunchScreen.storyboard */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = file.storyboard; name = LaunchScreen.storyboard; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
@@ -108,6 +133,13 @@
 			files = (
 				98EFD56DECBEF8FAFE851098 /* Foundation.framework in Frameworks */,
 				41BC57FB7B744BAA2ED75676 /* UIKit.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		6D1A124E231124EA004BBD77 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -165,6 +197,15 @@
 			name = iOS;
 			sourceTree = "<group>";
 		};
+		6D1A1252231124EA004BBD77 /* TestHostRC */ = {
+			isa = PBXGroup;
+			children = (
+				6D1A1253231124EA004BBD77 /* AppDelegate.swift */,
+				6D1A125F231124EB004BBD77 /* Info.plist */,
+			);
+			path = TestHostRC;
+			sourceTree = "<group>";
+		};
 		81FCBCFD5E5F4D6C608C8AFD = {
 			isa = PBXGroup;
 			children = (
@@ -190,7 +231,8 @@
 				3115B54847398B5D1FFDF8DD /* UnitTests.xctest */,
 				13671A9DCA6500C3546A770A /* FunctionalTests.xctest */,
 				CABEA84D5E02C4936A35AE92 /* Tests.xctest */,
-				921F4A6AA596AA8B63280A1F /* SampleApp.app */,
+				921F4A6AA596AA8B63280A1F /* RemoteConfig Sample.app */,
+				6D1A1251231124EA004BBD77 /* TestHostRC.app */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -205,6 +247,7 @@
 		E8FC29BA25F3DD5C53F63608 /* Tests */ = {
 			isa = PBXGroup;
 			children = (
+				6D1A1252231124EA004BBD77 /* TestHostRC */,
 				165B3D458505C24F782439C8 /* Unit */,
 				8A3181C0AC817C9BD5E53353 /* Functional */,
 			);
@@ -238,6 +281,7 @@
 			);
 			dependencies = (
 				3B3F5A013CB8074B3BA32933 /* PBXTargetDependency */,
+				6D1A126823114124004BBD77 /* PBXTargetDependency */,
 			);
 			name = Tests;
 			productName = Tests;
@@ -255,11 +299,29 @@
 			);
 			dependencies = (
 				8780174DAA8AC66E39DEED0F /* PBXTargetDependency */,
+				6D1A1264231126C2004BBD77 /* PBXTargetDependency */,
 			);
 			name = UnitTests;
 			productName = UnitTests;
 			productReference = 3115B54847398B5D1FFDF8DD /* UnitTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
+		};
+		6D1A1250231124EA004BBD77 /* TestHostRC */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 6D1A1260231124EB004BBD77 /* Build configuration list for PBXNativeTarget "TestHostRC" */;
+			buildPhases = (
+				6D1A124D231124EA004BBD77 /* Sources */,
+				6D1A124E231124EA004BBD77 /* Frameworks */,
+				6D1A124F231124EA004BBD77 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = TestHostRC;
+			productName = TestHostRC;
+			productReference = 6D1A1251231124EA004BBD77 /* TestHostRC.app */;
+			productType = "com.apple.product-type.application";
 		};
 		DE5E74061277FF3847A2D58E /* FunctionalTests */ = {
 			isa = PBXNativeTarget;
@@ -272,6 +334,7 @@
 			);
 			dependencies = (
 				E3F322303C8641AAE6CB17C0 /* PBXTargetDependency */,
+				6D1A126623113EE5004BBD77 /* PBXTargetDependency */,
 			);
 			name = FunctionalTests;
 			productName = FunctionalTests;
@@ -293,7 +356,7 @@
 			);
 			name = SampleApp;
 			productName = SampleApp;
-			productReference = 921F4A6AA596AA8B63280A1F /* SampleApp.app */;
+			productReference = 921F4A6AA596AA8B63280A1F /* RemoteConfig Sample.app */;
 			productType = "com.apple.product-type.application";
 		};
 /* End PBXNativeTarget section */
@@ -302,9 +365,26 @@
 		B32C06207C007144B4D259CF /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastSwiftUpdateCheck = 0930;
+				DefaultBuildSystemTypeForWorkspace = Original;
+				LastSwiftUpdateCheck = 1020;
 				LastUpgradeCheck = 1020;
 				ORGANIZATIONNAME = "Rakuten, Inc.";
+				TargetAttributes = {
+					0959466E288DA76D6CFA24FA = {
+						TestTargetID = 6D1A1250231124EA004BBD77;
+					};
+					4E6F50CD47B83B8FD5482426 = {
+						TestTargetID = 6D1A1250231124EA004BBD77;
+					};
+					6D1A1250231124EA004BBD77 = {
+						CreatedOnToolsVersion = 10.2;
+						DevelopmentTeam = 5J4GVGN58B;
+						ProvisioningStyle = Automatic;
+					};
+					DE5E74061277FF3847A2D58E = {
+						TestTargetID = 6D1A1250231124EA004BBD77;
+					};
+				};
 			};
 			buildConfigurationList = 0C6DF099CE72F2F8002EFD02 /* Build configuration list for PBXProject "RRemoteConfig" */;
 			compatibilityVersion = "Xcode 3.2";
@@ -323,6 +403,7 @@
 				DE5E74061277FF3847A2D58E /* FunctionalTests */,
 				0959466E288DA76D6CFA24FA /* Tests */,
 				F1FF84343DDC8BEF2A5AD7A5 /* SampleApp */,
+				6D1A1250231124EA004BBD77 /* TestHostRC */,
 			);
 		};
 /* End PBXProject section */
@@ -335,6 +416,13 @@
 				5250CF0315F00518AF2B7A7B /* Assets.xcassets in Resources */,
 				15BD1BFBC17FB82FDAE5DBC1 /* LaunchScreen.storyboard in Resources */,
 				D03E7804E7C3B443A4F475F6 /* Main.storyboard in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		6D1A124F231124EA004BBD77 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -397,6 +485,14 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		6D1A124D231124EA004BBD77 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				6D1A1254231124EA004BBD77 /* AppDelegate.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		DE93D3CE6126F5C72E4761B7 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -421,6 +517,21 @@
 			name = SampleApp;
 			target = F1FF84343DDC8BEF2A5AD7A5 /* SampleApp */;
 			targetProxy = B19ADC09B5005CB25EA03B8A /* PBXContainerItemProxy */;
+		};
+		6D1A1264231126C2004BBD77 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 6D1A1250231124EA004BBD77 /* TestHostRC */;
+			targetProxy = 6D1A1263231126C2004BBD77 /* PBXContainerItemProxy */;
+		};
+		6D1A126623113EE5004BBD77 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 6D1A1250231124EA004BBD77 /* TestHostRC */;
+			targetProxy = 6D1A126523113EE5004BBD77 /* PBXContainerItemProxy */;
+		};
+		6D1A126823114124004BBD77 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 6D1A1250231124EA004BBD77 /* TestHostRC */;
+			targetProxy = 6D1A126723114124004BBD77 /* PBXContainerItemProxy */;
 		};
 		8780174DAA8AC66E39DEED0F /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -466,7 +577,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				SDKROOT = iphoneos;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/SampleApp.app/SampleApp";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/TestHostRC.app/TestHostRC";
 			};
 			name = Debug;
 		};
@@ -537,7 +648,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				SDKROOT = iphoneos;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/SampleApp.app/SampleApp";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/TestHostRC.app/TestHostRC";
 			};
 			name = Debug;
 		};
@@ -549,8 +660,8 @@
 				INFOPLIST_FILE = Sample/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = com.rakuten.tech.SampleApp;
-				PRODUCT_NAME = "$(TARGET_NAME)";
+				PRODUCT_BUNDLE_IDENTIFIER = com.rakuten.tech.remoteconfig.SampleApp;
+				PRODUCT_NAME = "RemoteConfig Sample";
 				SDKROOT = iphoneos;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -629,8 +740,8 @@
 				INFOPLIST_FILE = Sample/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = com.rakuten.tech.SampleApp;
-				PRODUCT_NAME = "$(TARGET_NAME)";
+				PRODUCT_BUNDLE_IDENTIFIER = com.rakuten.tech.remoteconfig.SampleApp;
+				PRODUCT_NAME = "RemoteConfig Sample";
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALIDATE_PRODUCT = YES;
@@ -647,9 +758,47 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				SDKROOT = iphoneos;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/SampleApp.app/SampleApp";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/TestHostRC.app/TestHostRC";
 			};
 			name = Debug;
+		};
+		6D1A1261231124EB004BBD77 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = 5J4GVGN58B;
+				INFOPLIST_FILE = Tests/TestHostRC/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = jp.co.rakuten.sdk.TestHostRC;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		6D1A1262231124EB004BBD77 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = 5J4GVGN58B;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				INFOPLIST_FILE = Tests/TestHostRC/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = jp.co.rakuten.sdk.TestHostRC;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
 		};
 		DA0CE2CCF2AE42DB2A5CCD34 /* Release */ = {
 			isa = XCBuildConfiguration;
@@ -660,7 +809,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				SDKROOT = iphoneos;
-				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/SampleApp.app/SampleApp";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/TestHostRC.app/TestHostRC";
 				VALIDATE_PRODUCT = YES;
 			};
 			name = Release;
@@ -674,7 +823,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				SDKROOT = iphoneos;
-				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/SampleApp.app/SampleApp";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/TestHostRC.app/TestHostRC";
 				VALIDATE_PRODUCT = YES;
 			};
 			name = Release;
@@ -688,7 +837,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				SDKROOT = iphoneos;
-				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/SampleApp.app/SampleApp";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/TestHostRC.app/TestHostRC";
 				VALIDATE_PRODUCT = YES;
 			};
 			name = Release;
@@ -710,6 +859,15 @@
 			buildConfigurations = (
 				283010CC2219C05D30D1E72E /* Debug */,
 				0E1E502A7C55930CCBA2DFE4 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		6D1A1260231124EB004BBD77 /* Build configuration list for PBXNativeTarget "TestHostRC" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				6D1A1261231124EB004BBD77 /* Debug */,
+				6D1A1262231124EB004BBD77 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/RRemoteConfig.xcodeproj/xcshareddata/xcschemes/TestHostRC.xcscheme
+++ b/RRemoteConfig.xcodeproj/xcshareddata/xcschemes/TestHostRC.xcscheme
@@ -14,9 +14,9 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "F1FF84343DDC8BEF2A5AD7A5"
-               BuildableName = "RemoteConfig Sample.app"
-               BlueprintName = "SampleApp"
+               BlueprintIdentifier = "6D1A1250231124EA004BBD77"
+               BuildableName = "TestHostRC.app"
+               BlueprintName = "TestHostRC"
                ReferencedContainer = "container:RRemoteConfig.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
@@ -26,26 +26,15 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      codeCoverageEnabled = "YES"
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "4E6F50CD47B83B8FD5482426"
-               BuildableName = "UnitTests.xctest"
-               BlueprintName = "UnitTests"
-               ReferencedContainer = "container:RRemoteConfig.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
       </Testables>
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "F1FF84343DDC8BEF2A5AD7A5"
-            BuildableName = "RemoteConfig Sample.app"
-            BlueprintName = "SampleApp"
+            BlueprintIdentifier = "6D1A1250231124EA004BBD77"
+            BuildableName = "TestHostRC.app"
+            BlueprintName = "TestHostRC"
             ReferencedContainer = "container:RRemoteConfig.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
@@ -66,9 +55,9 @@
          runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "F1FF84343DDC8BEF2A5AD7A5"
-            BuildableName = "RemoteConfig Sample.app"
-            BlueprintName = "SampleApp"
+            BlueprintIdentifier = "6D1A1250231124EA004BBD77"
+            BuildableName = "TestHostRC.app"
+            BlueprintName = "TestHostRC"
             ReferencedContainer = "container:RRemoteConfig.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
@@ -76,20 +65,21 @@
       </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
-      buildConfiguration = "Debug"
+      buildConfiguration = "Release"
       shouldUseLaunchSchemeArgsEnv = "YES"
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
       debugDocumentVersioning = "YES">
-      <MacroExpansion>
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "F1FF84343DDC8BEF2A5AD7A5"
-            BuildableName = "RemoteConfig Sample.app"
-            BlueprintName = "SampleApp"
+            BlueprintIdentifier = "6D1A1250231124EA004BBD77"
+            BuildableName = "TestHostRC.app"
+            BlueprintName = "TestHostRC"
             ReferencedContainer = "container:RRemoteConfig.xcodeproj">
          </BuildableReference>
-      </MacroExpansion>
+      </BuildableProductRunnable>
    </ProfileAction>
    <AnalyzeAction
       buildConfiguration = "Debug">

--- a/RRemoteConfig/ConfigCache.swift
+++ b/RRemoteConfig/ConfigCache.swift
@@ -4,13 +4,13 @@ internal class ConfigCache {
     let cacheUrl: URL
     let keyStore: KeyStore
     let verifier: Verifier
-    private var activeConfig: ConfigModel? = ConfigModel(config: [:])
+    private var activeConfig: ConfigModel?
     private var numberFormatter: NumberFormatter
 
     init(fetcher: Fetcher,
          poller: Poller,
          cacheUrl: URL = FileManager.getCacheDirectory().appendingPathComponent("rrc-config.plist"),
-         initialCacheContents: [String: String]? = nil,
+         initialCacheContents: [String: Any]? = nil,
          keyStore: KeyStore = KeyStore(),
          verifier: Verifier = Verifier()) {
         self.fetcher = fetcher
@@ -20,17 +20,19 @@ internal class ConfigCache {
         self.keyStore = keyStore
         self.verifier = verifier
 
-        if let initialCacheContents = initialCacheContents {
-            self.activeConfig = ConfigModel(config: initialCacheContents)
+        if let initialCacheContents = initialCacheContents,
+            let data = try? JSONSerialization.data(withJSONObject: ["body": initialCacheContents], options: []) {
+            self.activeConfig = ConfigModel(data: data)
         }
         DispatchQueue.global(qos: .utility).async {
             if let dictionary = NSDictionary.init(contentsOf: self.cacheUrl) as? [String: Any] {
                 Logger.d("Config read from cache plist \(cacheUrl): \(dictionary)")
 
-                guard let configDic = dictionary["config"] as? [String: String] else {
-                    return
+                guard
+                    let configData = dictionary["config"] as? Data,
+                    var configModel = ConfigModel(data: configData) else {
+                    return Logger.e("Config data in cache is invalid")
                 }
-                var configModel = ConfigModel(config: configDic, keyId: dictionary["keyId"] as? String ?? "")
                 configModel.signature = dictionary["signature"] as? String
 
                 if self.verifyContents(model: configModel) {
@@ -46,81 +48,12 @@ internal class ConfigCache {
     func refreshFromRemote() {
         self.poller.start {
             DispatchQueue.global(qos: .utility).async {
-                self.fetcher.fetchConfig { (result) in
-                    guard let configModel = result else {
-                        return print("Config could not be refreshed from remote")
-                    }
-                    self.verifyContents(model: configModel, resultHandler: { (verified) in
-                        if verified {
-                            let dictionary = [
-                                "config": configModel.config,
-                                "keyId": configModel.keyId as Any,
-                                "signature": configModel.signature as Any
-                            ]
-                            self.write(dictionary)
-                        } else {
-                            Logger.e("Fetched dictionary contents failed verification")
-                        }
-                    })
-                }
+                self.fetchConfig()
             }
         }
     }
 
-    fileprivate func write(_ config: [String: Any]) {
-        DispatchQueue.global(qos: .utility).async {
-            NSDictionary(dictionary: config).write(to: self.cacheUrl, atomically: true)
-            let readFromPlist = NSDictionary(contentsOf: self.cacheUrl)
-            Logger.d("Config written to url \(self.cacheUrl):\n\n \(String(describing: readFromPlist))")
-        }
-    }
-}
-
-extension FileManager {
-    class func getCacheDirectory() -> URL {
-        let cachePaths = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask)
-        return cachePaths[0]
-    }
-}
-
-// MARK: Payload signature verification
-extension ConfigCache {
-    // synchronous verification with local key store
-    func verifyContents(model: ConfigModel) -> Bool {
-        guard let key = keyStore.key(for: model.keyId),
-            let signature = model.signature else {
-            return false
-        }
-        return self.verifier.verify(signatureBase64: signature,
-                                    dictionary: model.config,
-                                    keyBase64: key)
-    }
-
-    // asynchronous verification - fetches key from backend if key is not
-    // found in local key store
-    func verifyContents(model: ConfigModel, resultHandler: @escaping (Bool) -> Void ) {
-        if let key = keyStore.key(for: model.keyId) {
-            let verified = self.verifier.verify(signatureBase64: model.signature ?? "",
-                                                dictionary: model.config,
-                                                keyBase64: key)
-            resultHandler(verified)
-        } else {
-            fetcher.fetchKey(with: model.keyId) { (keyModel) in
-                guard let key = keyModel?.key, keyModel?.id == model.keyId else {
-                    return resultHandler(false)
-                }
-                self.keyStore.addKey(key: key, for: model.keyId)
-                let verified = self.verifier.verify(signatureBase64: model.signature ?? "",
-                                                    dictionary: model.config,
-                                                    keyBase64: key)
-                resultHandler(verified)
-            }
-        }
-    }
-}
-
-// MARK: Get config methods
-extension ConfigCache {
+    // MARK: Get config methods
     func getString(_ key: String, _ fallback: String) -> String {
         guard let config = activeConfig?.config else {
             return fallback
@@ -146,5 +79,82 @@ extension ConfigCache {
 
     func getConfig() -> [String: String] {
         return activeConfig?.config ?? [:]
+    }
+
+    // MARK: Private helpers
+    fileprivate func fetchConfig() {
+        self.fetcher.fetchConfig { (result) in
+            guard let configModel = result else {
+                return Logger.e("Config could not be refreshed from remote")
+            }
+            self.verifyContents(model: configModel, resultHandler: { (verified) in
+                if verified {
+                    let dictionary = [
+                        "config": configModel.jsonData,
+                        "signature": configModel.signature as Any
+                    ]
+                    self.write(dictionary)
+                } else {
+                    Logger.e("Fetched dictionary contents failed verification")
+                }
+            })
+        }
+    }
+
+    fileprivate func write(_ config: [String: Any]) {
+        DispatchQueue.global(qos: .utility).async {
+            NSDictionary(dictionary: config).write(to: self.cacheUrl, atomically: true)
+            let readFromPlist = NSDictionary(contentsOf: self.cacheUrl)
+            Logger.d("Config written to url \(self.cacheUrl):\n\n \(String(describing: readFromPlist))")
+        }
+    }
+}
+
+extension FileManager {
+    class func getCacheDirectory() -> URL {
+        let cachePaths = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask)
+        return cachePaths[0]
+    }
+}
+
+// MARK: Payload signature verification
+extension ConfigCache {
+    // synchronous verification with local key store
+    func verifyContents(model: ConfigModel) -> Bool {
+        guard let keyId = model.keyId,
+            let key = keyStore.key(for: keyId),
+            let signature = model.signature else {
+            return false
+        }
+        return self.verifier.verify(signatureBase64: signature,
+                                    objectData: model.jsonData,
+                                    keyBase64: key)
+    }
+
+    // asynchronous verification - fetches key from backend if key is not
+    // found in local key store
+    func verifyContents(model: ConfigModel, resultHandler: @escaping (Bool) -> Void ) {
+        guard let keyId = model.keyId,
+            let signature = model.signature else {
+                return resultHandler(false)
+        }
+
+        if let key = keyStore.key(for: keyId) {
+            let verified = self.verifier.verify(signatureBase64: signature,
+                                                objectData: model.jsonData,
+                                                keyBase64: key)
+            resultHandler(verified)
+        } else {
+            fetcher.fetchKey(with: keyId) { (keyModel) in
+                guard let key = keyModel?.key, keyModel?.id == model.keyId else {
+                    return resultHandler(false)
+                }
+                self.keyStore.addKey(key: key, for: keyId)
+                let verified = self.verifier.verify(signatureBase64: signature,
+                                                    objectData: model.jsonData,
+                                                    keyBase64: key)
+                resultHandler(verified)
+            }
+        }
     }
 }

--- a/RRemoteConfig/ConfigModel.swift
+++ b/RRemoteConfig/ConfigModel.swift
@@ -1,15 +1,39 @@
-internal struct ConfigModel: Decodable {
+protocol Parsable {
+    init?(data: Data)
+}
+
+internal struct ConfigModel: Parsable {
+    let jsonData: Data
     let config: [String: String]
-    let keyId: String
+    var keyId: String?
     var signature: String?
 
-    init(config: [String: String],
-         keyId: String = "") {
-        self.config = config
-        self.keyId = keyId
+    init?(data: Data) {
+        var dictionary: [String: Any]?
+        print("payload data as string: \(String(data: data, encoding: .utf8) ?? "data cannot be encoded to utf8 string")")
+        do {
+            dictionary = try JSONSerialization.jsonObject(with: data, options: []) as? [String: Any]
+        } catch let error {
+            Logger.e(error.localizedDescription)
+            return nil
+        }
+        self.jsonData = data
+        self.config = dictionary?["body"] as? [String: String] ?? [:]
+        self.keyId = dictionary?["keyId"] as? String
     }
+}
 
-    enum CodingKeys: String, CodingKey {
-        case keyId, config = "body"
+internal struct KeyModel: Decodable, Parsable {
+    let id: String
+    let key: String
+    let createdAt: String
+
+    init?(data: Data) {
+        guard let dictionary = try? JSONSerialization.jsonObject(with: data, options: []) as? [String: String] else {
+            return nil
+        }
+        self.id = dictionary["id"] ?? ""
+        self.key = dictionary["key"] ?? ""
+        self.createdAt = dictionary["createdAt"] ?? ""
     }
 }

--- a/RRemoteConfig/ConfigModel.swift
+++ b/RRemoteConfig/ConfigModel.swift
@@ -10,7 +10,7 @@ internal struct ConfigModel: Parsable {
 
     init?(data: Data) {
         var dictionary: [String: Any]?
-        print("payload data as string: \(String(data: data, encoding: .utf8) ?? "data cannot be encoded to utf8 string")")
+        Logger.d("Payload data as string: \(String(data: data, encoding: .utf8) ?? "data cannot be encoded to utf8 string")")
         do {
             dictionary = try JSONSerialization.jsonObject(with: data, options: []) as? [String: Any]
         } catch let error {

--- a/RRemoteConfig/Fetcher.swift
+++ b/RRemoteConfig/Fetcher.swift
@@ -8,6 +8,7 @@ internal class Fetcher {
         self.environment = environment
     }
 
+    // MARK: Fetch Config
     func fetchConfig(completionHandler: @escaping (ConfigModel?) -> Void) {
         guard let url = environment.configUrl else {
             return completionHandler(nil)
@@ -15,20 +16,22 @@ internal class Fetcher {
         var request = URLRequest(url: url)
         request.setConfigHeaders(from: environment)
 
-        apiClient.send(request: request, decodeAs: ConfigModel.self) { (result, response) in
+        apiClient.send(request: request, parser: ConfigModel.self) { (result) in
             switch result {
-            case .success(let resultConfig):
-                var config = resultConfig as? ConfigModel
-                config?.signature = response?.allHeaderFields["Signature"] as? String
-                self.environment.etag = response?.allHeaderFields["Etag"] as? String
+            case .success(let response):
+                var config = response.object as? ConfigModel
+                let headers = response.httpResponse.allHeaderFields as? [String: String]
+                config?.signature = headers?["Signature"]
+                self.environment.etag = headers?["Etag"]
                 completionHandler(config)
             case .failure(let error):
-                Logger.e("Config fetch url \(String(describing: request.url)) received error \(error.localizedDescription) for response \(String(describing: response))")
+                Logger.e("Config fetch \(String(describing: request.url)) error occurred: \(error.localizedDescription)")
                 completionHandler(nil)
             }
         }
     }
 
+    // MARK: Fetch Key
     func fetchKey(with keyId: String, completionHandler: @escaping (KeyModel?) -> Void) {
         guard let url = environment.keyUrl(with: keyId) else {
             return completionHandler(nil)
@@ -36,20 +39,14 @@ internal class Fetcher {
         var request = URLRequest(url: url)
         request.addHeader("apiKey", "ras-\(environment.subscriptionKey)")
 
-        apiClient.send(request: request, decodeAs: KeyModel.self) { (result, response) in
+        apiClient.send(request: request, parser: KeyModel.self) { (result) in
             switch result {
-            case .success(let keyModel):
-                completionHandler(keyModel as? KeyModel)
+            case .success(let response):
+                completionHandler(response.object as? KeyModel)
             case .failure(let error):
-                Logger.e("Key fetch url \(String(describing: request.url)) received error \(error.localizedDescription) for response \(String(describing: response))")
+                Logger.e("Key fetch \(String(describing: request.url)) error occurred: \(error.localizedDescription)")
                 completionHandler(nil)
             }
         }
     }
-}
-
-internal struct KeyModel: Decodable {
-    let id: String
-    let key: String
-    let createdAt: String
 }

--- a/RRemoteConfig/Verifier.swift
+++ b/RRemoteConfig/Verifier.swift
@@ -1,17 +1,10 @@
 internal class Verifier {
     func verify(signatureBase64: String,
-                dictionary: [String: Any],
+                objectData: Data,
                 keyBase64: String) -> Bool {
         guard let secKey = createSecKey(for: keyBase64),
             let signatureData = Data(base64Encoded: signatureBase64) else {
                 return false
-        }
-
-        var objectData: Data = Data()
-        do {
-            objectData = try JSONSerialization.data(withJSONObject: dictionary, options: [])
-        } catch {
-            return false
         }
 
         var error: Unmanaged<CFError>?

--- a/Sample/AppDelegate.swift
+++ b/Sample/AppDelegate.swift
@@ -7,11 +7,17 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     var window: UIWindow?
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
-        let val1 = RemoteConfig.getString(key: "foo", fallback: "bar")
-        print("key: foo, fallback: bar -> val1: \(val1)")
+        checkConfig()
+        DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + DispatchTimeInterval.seconds(5)) {
+            self.checkConfig()
+        }
+        return true
+    }
+
+    func checkConfig() {
+        let val1 = RemoteConfig.getString(key: "foo", fallback: "nope")
+        print("key: foo, fallback: nope -> val1: \(val1)")
         let val2 = RemoteConfig.getString(key: "key", fallback: "oops")
         print("key: key, fallback: oops -> val2: \(val2)")
-        print(RemoteConfig.getConfig())
-        return true
     }
 }

--- a/Tests/TestHostRC/AppDelegate.swift
+++ b/Tests/TestHostRC/AppDelegate.swift
@@ -1,0 +1,5 @@
+import UIKit
+
+@UIApplicationMain
+class AppDelegate: UIResponder, UIApplicationDelegate {
+}

--- a/Tests/TestHostRC/Info.plist
+++ b/Tests/TestHostRC/Info.plist
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>UIRequiredDeviceCapabilities</key>
+	<array>
+		<string>armv7</string>
+	</array>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>UISupportedInterfaceOrientations~ipad</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>RASApplicationIdentifier</key>
+	<string>APPLICATION_IDENTIFIER</string>
+	<key>RASProjectSubscriptionKey</key>
+	<string>SUBSCRIPTION_KEY</string>
+	<key>RRCConfigAPIEndpoint</key>
+	<string>https://performance-endpoint.com</string>
+</dict>
+</plist>

--- a/Tests/Unit/APIClientTests.swift
+++ b/Tests/Unit/APIClientTests.swift
@@ -3,8 +3,15 @@ import Nimble
 @testable import RRemoteConfig
 
 class APIClientSpec: QuickSpec {
-    struct TestStruct: Decodable, Equatable {
-        let foo: String
+    struct TestStruct: Parsable, Equatable {
+        let foo: [String: String]
+
+        init?(data: Data) {
+            guard let foo = try? JSONSerialization.jsonObject(with: data, options: []) as? [String: String] else {
+                return nil
+            }
+            self.foo = foo
+        }
     }
     override func spec() {
         describe("send function") {
@@ -17,7 +24,7 @@ class APIClientSpec: QuickSpec {
                     let response = HTTPURLResponse(url: URL(string: "https://test.com")!, statusCode: serverErrorCode ?? 0, httpVersion: "1", headerFields: nil)
                     var data: Data?
                     if let json = jsonObj {
-                        data = try? JSONSerialization.data(withJSONObject: json, options: .prettyPrinted)
+                        data = try? JSONSerialization.data(withJSONObject: json, options: [])
                     }
                     completionHandler(data, response, error)
                 }
@@ -29,20 +36,21 @@ class APIClientSpec: QuickSpec {
                 }
             }
             context("when network response contains valid result json") {
-                var testResult: TestStruct = TestStruct(foo: "")
+                var testResult: TestStruct?
 
                 it("will pass a result to completion handler with expected value") {
                     let sessionMock = SessionMock(json: ["foo": "bar"])
-                    APIClient(session: sessionMock).send(request: URLRequest(url: URL(string: "https://test.com")!), decodeAs: TestStruct.self, completionHandler: { (result, _) in
+                    let jsonData = (try? JSONSerialization.data(withJSONObject: ["foo": "bar"], options: []))!
+                    APIClient(session: sessionMock).send(request: URLRequest(url: URL(string: "https://test.com")!), parser: TestStruct.self, completionHandler: {(result) in
                         switch result {
-                        case .success(let obj):
-                            testResult = obj as? TestStruct ?? TestStruct(foo: "foo")
+                        case .success(let response):
+                            testResult = (response.object as? TestStruct)!
                         case .failure:
                             break
                         }
                     })
 
-                    expect(testResult).toEventually(equal(TestStruct(foo: "bar")), timeout: 2)
+                    expect(testResult).toEventually(equal(TestStruct(data: jsonData)), timeout: 2)
                 }
             }
             context("when network response contains valid error json") {
@@ -50,7 +58,7 @@ class APIClientSpec: QuickSpec {
 
                 it("will pass an error to completion handler with expected code") {
                     let sessionMock = SessionMock(json: ["code": 1, "message": "error message"])
-                    APIClient(session: sessionMock).send(request: URLRequest(url: URL(string: "https://test.com")!), decodeAs: TestStruct.self, completionHandler: { (result, _) in
+                    APIClient(session: sessionMock).send(request: URLRequest(url: URL(string: "https://test.com")!), parser: TestStruct.self, completionHandler: { (result) in
                         switch result {
                         case .success:
                             break
@@ -64,7 +72,7 @@ class APIClientSpec: QuickSpec {
 
                 it("will pass an error to completion handler with expected message") {
                     let sessionMock = SessionMock(json: ["code": 1, "message": "error message"])
-                    APIClient(session: sessionMock).send(request: URLRequest(url: URL(string: "https://test.com")!), decodeAs: TestStruct.self, completionHandler: { (result, _) in
+                    APIClient(session: sessionMock).send(request: URLRequest(url: URL(string: "https://test.com")!), parser: TestStruct.self, completionHandler: { (result) in
                         switch result {
                         case .success:
                             break
@@ -80,7 +88,7 @@ class APIClientSpec: QuickSpec {
                 it("will pass a non-nil error to completion handler") {
                     var testError: NSError = NSError.init(domain: "Test", code: 0, userInfo: nil)
                     let sessionMock = SessionMock(json: ["foo": "bar"])
-                    APIClient(session: sessionMock).send(request: URLRequest(url: URL(string: "https://test.com")!), decodeAs: TestStruct.self, completionHandler: { (result, _) in
+                    APIClient(session: sessionMock).send(request: URLRequest(url: URL(string: "https://test.com")!), parser: TestStruct.self, completionHandler: { (result) in
                         switch result {
                         case .success:
                             break
@@ -97,7 +105,7 @@ class APIClientSpec: QuickSpec {
 
                 it("will pass an error with code set to server status code to completion handler and error is nil") {
                     let sessionMock = SessionMock(json: nil, statusCode: 400)
-                    APIClient(session: sessionMock).send(request: URLRequest(url: URL(string: "https://test.com")!), decodeAs: TestStruct.self, completionHandler: { (result, _) in
+                    APIClient(session: sessionMock).send(request: URLRequest(url: URL(string: "https://test.com")!), parser: TestStruct.self, completionHandler: { (result) in
                         switch result {
                         case .success:
                             break
@@ -111,7 +119,7 @@ class APIClientSpec: QuickSpec {
 
                 it("will pass any system error to completion handler even when response received") {
                     let sessionMock = SessionMock(json: nil, error: NSError(domain: "Test", code: 123, userInfo: nil))
-                    APIClient(session: sessionMock).send(request: URLRequest(url: URL(string: "https://test.com")!), decodeAs: TestStruct.self, completionHandler: { (result, _) in
+                    APIClient(session: sessionMock).send(request: URLRequest(url: URL(string: "https://test.com")!), parser: TestStruct.self, completionHandler: { (result) in
                         switch result {
                         case .success:
                             break

--- a/Tests/Unit/ConfigCacheTests.swift
+++ b/Tests/Unit/ConfigCacheTests.swift
@@ -42,7 +42,6 @@ class ConfigCacheSpec: QuickSpec {
                 beforeEach {
                     let written = NSDictionary(dictionary:
                         ["config": jsonData,
-                         "keyId": "1234",
                          "signature": "sigfoo"
                         ]).write(to: url, atomically: true)
                     print("test data written to cache url \(url): \(String(describing: written))")

--- a/Tests/Unit/ConfigFetcherTests.swift
+++ b/Tests/Unit/ConfigFetcherTests.swift
@@ -148,7 +148,7 @@ class ConfigFetcherSpec: QuickSpec {
                 it("will set the config dictionary in the result passed to the completion handler") {
                     var testResult: Any?
                     let apiClientMock = APIClientMock()
-                    apiClientMock.dictionary = ["foo": "bar"]
+                    apiClientMock.dictionary = ["body": ["foo": "bar"]]
                     let fetcher = Fetcher(client: apiClientMock, environment: Environment())
 
                     fetcher.fetchConfig(completionHandler: { (result) in
@@ -173,15 +173,17 @@ class ConfigFetcherSpec: QuickSpec {
                 }
 
                 it("will save the etag to user defaults") {
+                    UserDefaults.standard.removeObject(forKey: Environment.etagKey)
                     let apiClientMock = APIClientMock()
-                    apiClientMock.dictionary = ["foo": "bar"]
+                    let env = Environment()
+                    apiClientMock.dictionary = ["body": ["foo": "bar"]]
                     apiClientMock.headers = ["Etag": "an-etag"]
-                    let fetcher = Fetcher(client: apiClientMock, environment: Environment())
+                    let fetcher = Fetcher(client: apiClientMock, environment: env)
 
                     fetcher.fetchConfig(completionHandler: { (_) in
                     })
 
-                    expect(UserDefaults.standard.string(forKey: Environment.etagKey)).toEventually(equal("an-etag"))
+                    expect(env.etag).toEventually(equal("an-etag"), timeout: 2)
                 }
             }
 

--- a/Tests/Unit/VerifierTests.swift
+++ b/Tests/Unit/VerifierTests.swift
@@ -10,21 +10,21 @@ import XCTest
 class VerifierSpec: QuickSpec {
     override func spec() {
         let verifier = Verifier()
-        let originalPayload = ["testKey": "test_value"]
+        let jsonData = (try? JSONSerialization.data(withJSONObject: ["testKey": "test_value"], options: []))!
         let signature = "MEUCIQCHJfSffJ+yjuCAvH3HKprbSn3XqUtZm9a+6+w2GILfywIgOkpFyaPNyQReaylbuhegQpPS+uVDwczbUsKZtaHcSnw="
         let key = "BI2zZr56ghnMLXBMeC4bkIVg6zpFD2ICIS7V6cWo8p8LkibuershO+Hd5ru6oBFLlUk6IFFOIVfHKiOenHLBNIY="
 
         it("should verify the signature of the original payload") {
             let verified = verifier.verify(signatureBase64: signature,
-                                           dictionary: originalPayload,
+                                           objectData: jsonData,
                                            keyBase64: key)
             expect(verified).to(beTrue())
         }
 
         it("should not verify the signature of a modified payload") {
-            let modifiedPayload = ["testKey": "another_value"]
+            let jsonData = (try? JSONSerialization.data(withJSONObject: ["testKey": "different_value"], options: []))!
             let verified = verifier.verify(signatureBase64: signature,
-                                           dictionary: modifiedPayload,
+                                           objectData: jsonData,
                                            keyBase64: key)
             expect(verified).to(beFalse())
         }


### PR DESCRIPTION
# Description
Cache and verify against the response payload data.

- update Verifier to take a data parameter
- create a Response struct that conforms to a Parseable protocol
- use Response as the parameter type passed to the APIClient's send request function's completionHandler in the success case
- refactor ConfigCache to cache the response payload
- use an empty test app as the tests host

## Links
SDKCF-1363

# Checklist
- [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [x] I wrote/updated tests for new/changed code
- [x] I ran `fastlane ci` without errors
