### PR TITLE
fix: strip any extra newline from the config response json data

### DIFF
--- a/RRemoteConfig.xcodeproj/project.pbxproj
+++ b/RRemoteConfig.xcodeproj/project.pbxproj
@@ -32,6 +32,8 @@
 		6DBD474822DD716F00AA21CD /* TestHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DBD474722DD716F00AA21CD /* TestHelpers.swift */; };
 		6DBD474922DD716F00AA21CD /* TestHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DBD474722DD716F00AA21CD /* TestHelpers.swift */; };
 		6DBD474A22DD716F00AA21CD /* TestHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DBD474722DD716F00AA21CD /* TestHelpers.swift */; };
+		6DE1D694232770DD0040B6BA /* ConfigModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DE1D693232770DD0040B6BA /* ConfigModelTests.swift */; };
+		6DE1D695232770DD0040B6BA /* ConfigModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DE1D693232770DD0040B6BA /* ConfigModelTests.swift */; };
 		7C216026A4A4ED6E546CAAC5 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 904EAA9F750B684EFBA9CC89 /* AppDelegate.swift */; };
 		82D829D568E3802FAA896998 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 19982D0FEBA288B67DF40F7F /* UIKit.framework */; };
 		84B8D48A7BB398B5015D0B48 /* FunctionalTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF48B14075CAE45D72E1AB89 /* FunctionalTests.swift */; };
@@ -105,6 +107,7 @@
 		6D622B2022BB1251001FD625 /* RealRemoteConfigTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RealRemoteConfigTests.swift; sourceTree = "<group>"; };
 		6D622B2322BB1271001FD625 /* ConfigCacheTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfigCacheTests.swift; sourceTree = "<group>"; };
 		6DBD474722DD716F00AA21CD /* TestHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestHelpers.swift; sourceTree = "<group>"; };
+		6DE1D693232770DD0040B6BA /* ConfigModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfigModelTests.swift; sourceTree = "<group>"; };
 		904EAA9F750B684EFBA9CC89 /* AppDelegate.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		921F4A6AA596AA8B63280A1F /* RemoteConfig Sample.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "RemoteConfig Sample.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		C9C9862DDDEEB8A1DAAF4A40 /* Assets.xcassets */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -176,6 +179,7 @@
 				6D307D2022E9BCAD00D4E115 /* VerifierTests.swift */,
 				6D307D2222E9BD6100D4E115 /* KeyStoreTests.swift */,
 				6DBD474722DD716F00AA21CD /* TestHelpers.swift */,
+				6DE1D693232770DD0040B6BA /* ConfigModelTests.swift */,
 			);
 			path = Unit;
 			sourceTree = "<group>";
@@ -478,6 +482,7 @@
 				6D622B1922BA243D001FD625 /* APIClientTests.swift in Sources */,
 				6D307D2122E9BCAD00D4E115 /* VerifierTests.swift in Sources */,
 				6DBD474A22DD716F00AA21CD /* TestHelpers.swift in Sources */,
+				6DE1D695232770DD0040B6BA /* ConfigModelTests.swift in Sources */,
 				6D622B1C22BA25B8001FD625 /* FetcherTests.swift in Sources */,
 				6D622B2222BB1251001FD625 /* RealRemoteConfigTests.swift in Sources */,
 				1501D850F5EB55B70B2890C3 /* EnvironmentTests.swift in Sources */,
@@ -498,6 +503,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				6D622B2422BB1271001FD625 /* ConfigCacheTests.swift in Sources */,
+				6DE1D694232770DD0040B6BA /* ConfigModelTests.swift in Sources */,
 				6DBD474822DD716F00AA21CD /* TestHelpers.swift in Sources */,
 				9A907C265DBCF37473D7AB76 /* EnvironmentTests.swift in Sources */,
 				6D307D2522E9BF2E00D4E115 /* VerifierTests.swift in Sources */,

--- a/RRemoteConfig/APIClient.swift
+++ b/RRemoteConfig/APIClient.swift
@@ -12,12 +12,10 @@ extension URLSession: SessionProtocol {
 
 internal struct Response {
     let object: Parsable
-    let data: Data
     let httpResponse: HTTPURLResponse
 
-    init(_ object: Parsable, _ data: Data, _ response: HTTPURLResponse) {
+    init(_ object: Parsable, _ response: HTTPURLResponse) {
         self.object = object
-        self.data = data
         self.httpResponse = response
     }
 }
@@ -36,7 +34,7 @@ internal class APIClient {
             if let httpResponse = response as? HTTPURLResponse,
                 let payloadData = data,
                 let object = parser.init(data: payloadData) {
-                return completionHandler(.success(Response(object, payloadData, httpResponse)))
+                return completionHandler(.success(Response(object, httpResponse)))
             }
 
             // Error handling:
@@ -52,6 +50,7 @@ internal class APIClient {
                 return completionHandler(.failure(NSError.serverError(code: errorModel.code, message: errorModel.message)))
             } catch {
                 let serverError = NSError.serverError(code: (response as? HTTPURLResponse)?.statusCode ?? 0, message: "Unspecified server error occurred")
+                Logger.e("Error: \(String(describing: serverError))")
                 return completionHandler(.failure(serverError))
             }
         }

--- a/RRemoteConfig/ConfigCache.swift
+++ b/RRemoteConfig/ConfigCache.swift
@@ -26,7 +26,7 @@ internal class ConfigCache {
         }
         DispatchQueue.global(qos: .utility).async {
             if let dictionary = NSDictionary.init(contentsOf: self.cacheUrl) as? [String: Any] {
-                Logger.d("Config read from cache plist \(cacheUrl): \(dictionary)")
+                Logger.v("Config read from cache plist \(cacheUrl): \(dictionary)")
 
                 guard
                     let configData = dictionary["config"] as? Data,
@@ -36,7 +36,7 @@ internal class ConfigCache {
                 configModel.signature = dictionary["signature"] as? String
 
                 if self.verifyContents(model: configModel) {
-                    Logger.d("Set active config to cached contents")
+                    Logger.d("Cached contents verified -> set as active config")
                     self.activeConfig = configModel
                 } else {
                     Logger.e("Cached dictionary contents failed verification")
@@ -105,7 +105,8 @@ internal class ConfigCache {
         DispatchQueue.global(qos: .utility).async {
             NSDictionary(dictionary: config).write(to: self.cacheUrl, atomically: true)
             let readFromPlist = NSDictionary(contentsOf: self.cacheUrl)
-            Logger.d("Config written to url \(self.cacheUrl):\n\n \(String(describing: readFromPlist))")
+            Logger.d("Fetched config verified and cached")
+            Logger.v("Contents written to url \(self.cacheUrl):\n\(String(describing: readFromPlist))")
         }
     }
 }

--- a/RRemoteConfig/KeyStore.swift
+++ b/RRemoteConfig/KeyStore.swift
@@ -21,7 +21,9 @@ internal class KeyStore {
             return nil
         }
 
-        return String(data: objectData, encoding: .utf8)
+        let key = String(data: objectData, encoding: .utf8)
+        Logger.v("Key id \(keyId) matched to key \(String(describing: key))")
+        return key
     }
 
     func addKey(key: String, for keyId: String) {
@@ -53,10 +55,13 @@ internal class KeyStore {
         }
 
         if status != errSecSuccess {
+            var error: String?
             if #available(iOS 11.3, *) {
-                let error = SecCopyErrorMessageString(status, nil)
-                Logger.e("addKey error \(String(describing: error))")
+                error = SecCopyErrorMessageString(status, nil) as String?
+            } else {
+                error = "OSStatus \(status)"
             }
+            Logger.e("addKey error \(String(describing: error))")
         }
     }
 }

--- a/RRemoteConfig/Logger.swift
+++ b/RRemoteConfig/Logger.swift
@@ -17,10 +17,17 @@ internal class Logger {
         #endif
     }
 
+    /// Verbose
+    class func v(_ message: String) {
+        #if DEBUG
+        //print("🔍 \(message)")
+        #endif
+    }
+
     /// Error
     class func e(_ message: String) {
         #if DEBUG
-        print("💣 \(message)")
+        print("❌ \(message)")
         #else
         os_log("%@", log: OSLog.sdk, type: .error, message)
         #endif

--- a/RRemoteConfig/Verifier.swift
+++ b/RRemoteConfig/Verifier.swift
@@ -2,6 +2,7 @@ internal class Verifier {
     func verify(signatureBase64: String,
                 objectData: Data,
                 keyBase64: String) -> Bool {
+        Logger.v("Verify data for \(String(describing: String(data: objectData, encoding: .utf8))) with signature \(signatureBase64) and key \(keyBase64)")
         guard let secKey = createSecKey(for: keyBase64),
             let signatureData = Data(base64Encoded: signatureBase64) else {
                 return false
@@ -13,6 +14,7 @@ internal class Verifier {
                                              objectData as CFData,
                                              signatureData as CFData,
                                              &error)
+        Logger.v("Verified: \(String(describing: verified))")
         if let err = error as? Error {
             Logger.e(err.localizedDescription)
         }
@@ -36,7 +38,7 @@ internal class Verifier {
             }
             return nil
         }
-        Logger.d("Key created: \(String(describing: secKey))")
+        Logger.v("Key created: \(String(describing: secKey))")
 
         if !SecKeyIsAlgorithmSupported(secKey, .verify, .ecdsaSignatureMessageX962SHA256) {
             Logger.e("Key doesn't support algorithm ecdsaSignatureMessageX962SHA256")

--- a/Tests/Unit/ConfigModelTests.swift
+++ b/Tests/Unit/ConfigModelTests.swift
@@ -1,0 +1,62 @@
+import Quick
+import Nimble
+@testable import RRemoteConfig
+
+class ConfigModelSpec: QuickSpec {
+    override func spec() {
+        context("initialization") {
+            describe("when json is the expected format") {
+                let data = """
+                    {"body":{"key1":"val1","key2":"val2","key3":"val3"},"keyId":"a1b2c3"}
+                    """.data(using: .utf8) ?? Data()
+                let config = ConfigModel(data: data)
+
+                it("stores the original data in the jsonData property") {
+                    expect(config?.jsonData).to(equal(data))
+                }
+
+                it("sets the config dictionary with the expected number of keys") {
+                    expect(config?.config.count).to(equal(["key1": "val1", "key2": "val2", "key3": "val3"].count))
+                }
+
+                it("sets the config dictionary with the expected key-value") {
+                    expect(config?.config["key1"]).to(equal("val1"))
+                }
+
+                it("sets the expected key id") {
+                    expect(config?.keyId).to(equal("a1b2c3"))
+                }
+            }
+            describe("when json is not the expected format") {
+                it("returns nil when json cannot be serialized") {
+                    let config = ConfigModel(data: "\"string\"".data(using: .utf8) ?? Data())
+
+                    expect(config).to(beNil())
+                }
+
+                it("returns nil when json does not have a body object") {
+                    let dataString = """
+                    "key1":"val1","key2":"val2","key3":"val3","keyId":"a1b2c3"
+                    """
+                    let config = ConfigModel(data: dataString.data(using: .utf8) ?? Data())
+
+                    expect(config).to(beNil())
+                }
+            }
+            describe("when json has unexpected newline") {
+                it("stores the modified data with the newline trimmed in the jsonData property") {
+                    let dataWithNewline = """
+                    {"body":{"key1":"val1","key2":"val2","key3":"val3"},"keyId":"a1b2c3"}
+
+                    """.data(using: .utf8) ?? Data()
+                    let config = ConfigModel(data: dataWithNewline)
+                    let dataWithoutNewline = """
+                    {"body":{"key1":"val1","key2":"val2","key3":"val3"},"keyId":"a1b2c3"}
+                    """.data(using: .utf8)
+
+                    expect(config?.jsonData).to(equal(dataWithoutNewline))
+                }
+            }
+        }
+    }
+}

--- a/Tests/Unit/FetcherTests.swift
+++ b/Tests/Unit/FetcherTests.swift
@@ -148,7 +148,10 @@ class FetcherSpec: QuickSpec {
                 it("will set the config dictionary in the result passed to the completion handler") {
                     var testResult: Any?
                     let apiClientMock = APIClientMock()
-                    apiClientMock.dictionary = ["body": ["foo": "bar"]]
+                    let dataString = """
+                        {"body":{"foo":"bar"}}
+                        """
+                    apiClientMock.data = dataString.data(using: .utf8)
                     let fetcher = Fetcher(client: apiClientMock, environment: Environment())
 
                     fetcher.fetchConfig(completionHandler: { (result) in
@@ -161,7 +164,10 @@ class FetcherSpec: QuickSpec {
                 it("will set the signature in the result passed to the completion handler") {
                     var testResult: Any?
                     let apiClientMock = APIClientMock()
-                    apiClientMock.dictionary = ["foo": "bar"]
+                    let dataString = """
+                        {"body":{"foo":"bar"}}
+                        """
+                    apiClientMock.data = dataString.data(using: .utf8)
                     apiClientMock.headers = ["Signature": "a-sig"]
                     let fetcher = Fetcher(client: apiClientMock, environment: Environment())
 
@@ -176,7 +182,10 @@ class FetcherSpec: QuickSpec {
                     UserDefaults.standard.removeObject(forKey: Environment.etagKey)
                     let apiClientMock = APIClientMock()
                     let env = Environment()
-                    apiClientMock.dictionary = ["body": ["foo": "bar"]]
+                    let dataString = """
+                        {"body":{"foo":"bar"}}
+                        """
+                    apiClientMock.data = dataString.data(using: .utf8)
                     apiClientMock.headers = ["Etag": "an-etag"]
                     let fetcher = Fetcher(client: apiClientMock, environment: env)
 
@@ -345,7 +354,10 @@ class FetcherSpec: QuickSpec {
                 it("will set the config dictionary in the result passed to the completion handler") {
                     var testResult: Any?
                     let apiClientMock = APIClientMock()
-                    apiClientMock.dictionary = ["id": "foo", "key": "myKeyId", "createdAt": "boo" ]
+                    let dataString = """
+                        {"id":"foo","key":"myKeyId","createdAt":"boo"}
+                        """
+                    apiClientMock.data = dataString.data(using: .utf8)
                     let fetcher = Fetcher(client: apiClientMock, environment: Environment())
 
                     fetcher.fetchKey(with: "key", completionHandler: { (result) in

--- a/Tests/Unit/TestHelpers.swift
+++ b/Tests/Unit/TestHelpers.swift
@@ -102,7 +102,7 @@ class KeyStoreMock: KeyStore {
 }
 
 class APIClientMock: APIClient {
-    var dictionary: [String: Any]?
+    var data: Data?
     var headers: [String: String]?
     var error: Error?
     var request: URLRequest?
@@ -110,13 +110,12 @@ class APIClientMock: APIClient {
     override func send<T>(request: URLRequest, parser: T.Type, completionHandler: @escaping (Result<Response, Error>) -> Void) where T: Parsable {
         self.request = request
 
-        guard let dictionary = dictionary else {
+        guard let data = data else {
             return completionHandler(.failure(error ?? NSError(domain: "Test", code: 0, userInfo: nil)))
         }
         if let httpResponse = HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: "1.1", headerFields: headers),
-            let jsonData = try? JSONSerialization.data(withJSONObject: dictionary, options: []),
-            let object = parser.init(data: jsonData) {
-            return completionHandler(.success(Response(object, jsonData, httpResponse)))
+            let object = parser.init(data: data) {
+            return completionHandler(.success(Response(object, httpResponse)))
         }
     }
 }


### PR DESCRIPTION
# Description
Strip any extra newline from the config response json data so that the data can be verified successfully
- also add more debug logging to help track down similar issues
- split debug logging into normal and verbose and disable verbose by default
- add config model tests

## Links
SDKCF-1463

# Checklist
- [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [x] I wrote/updated tests for new/changed code
- [x] I ran `fastlane ci` without errors
