### PR TITLE
improvement: use guards instead of optional unwrapping in the models

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,5 +24,5 @@ Pods
 # Jazzy-generated documentation
 docs/
 
-# Always use latest gems
+# Use latest gem versions
 Gemfile.lock

--- a/RRemoteConfig/ConfigCache.swift
+++ b/RRemoteConfig/ConfigCache.swift
@@ -10,7 +10,7 @@ internal class ConfigCache {
     init(fetcher: Fetcher,
          poller: Poller,
          cacheUrl: URL = FileManager.getCacheDirectory().appendingPathComponent("rrc-config.plist"),
-         initialCacheContents: [String: Any]? = nil,
+         initialCacheContents: Data? = nil,
          keyStore: KeyStore = KeyStore(),
          verifier: Verifier = Verifier()) {
         self.fetcher = fetcher
@@ -20,8 +20,7 @@ internal class ConfigCache {
         self.keyStore = keyStore
         self.verifier = verifier
 
-        if let initialCacheContents = initialCacheContents,
-            let data = try? JSONSerialization.data(withJSONObject: ["body": initialCacheContents], options: []) {
+        if let data = initialCacheContents {
             self.activeConfig = ConfigModel(data: data)
         }
         DispatchQueue.global(qos: .utility).async {

--- a/RRemoteConfig/Logger.swift
+++ b/RRemoteConfig/Logger.swift
@@ -20,6 +20,8 @@ internal class Logger {
     /// Verbose
     class func v(_ message: String) {
         #if DEBUG
+        // Disabled by default to prevent spamming apps with verbose logging.
+        // In future this could be made switchable via plist.
         //print("🔍 \(message)")
         #endif
     }

--- a/RRemoteConfig/Models.swift
+++ b/RRemoteConfig/Models.swift
@@ -22,9 +22,14 @@ internal struct ConfigModel: Parsable {
             return nil
         }
 
+        guard let config = dictionary?["body"] as? ConfigDictionary,
+            let keyId = dictionary?["keyId"] as? String else {
+            return nil
+        }
+
         self.jsonData = jsonData.trailingNewlineTrimmed()
-        self.config = dictionary?["body"] as? ConfigDictionary ?? [:]
-        self.keyId = dictionary?["keyId"] as? String ?? ""
+        self.config =  config
+        self.keyId =  keyId
     }
 }
 
@@ -46,7 +51,7 @@ internal struct KeyModel: Decodable, Parsable {
     }
 }
 
-extension Data {
+fileprivate extension Data {
     mutating func trailingNewlineTrimmed() -> Data {
         let data = self
         guard let dataString = String(data: data, encoding: .utf8) else {

--- a/RRemoteConfig/Verifier.swift
+++ b/RRemoteConfig/Verifier.swift
@@ -33,7 +33,7 @@ internal class Verifier {
 
         var error: Unmanaged<CFError>?
         guard let secKey = SecKeyCreateWithData(secKeyData as CFData, attributes as CFDictionary, &error) else {
-            if let err = error as? Error {
+            if let err = error?.takeRetainedValue() {
                 Logger.e(err.localizedDescription)
             }
             return nil

--- a/Tests/Unit/ConfigCacheTests.swift
+++ b/Tests/Unit/ConfigCacheTests.swift
@@ -91,7 +91,7 @@ class ConfigCacheSpec: QuickSpec {
             let fetcher = Fetcher(client: APIClient(), environment: Environment())
 
             it("returns the value from config when key exists in config") {
-                let configCache = ConfigCache(fetcher: fetcher, poller: Poller(), initialCacheContents: ["foo": "bar"])
+                let configCache = ConfigCache(fetcher: fetcher, poller: Poller(), initialCacheContents: #"{"body":{"foo":"bar"},"keyId":"fooKey"}"#.data(using: .utf8))
 
                 let value = configCache.getString("foo", "not found")
 
@@ -99,7 +99,7 @@ class ConfigCacheSpec: QuickSpec {
             }
 
             it("returns the fallback when key is not found in config") {
-                let configCache = ConfigCache(fetcher: fetcher, poller: Poller(), initialCacheContents: ["moo": "bar"])
+                let configCache = ConfigCache(fetcher: fetcher, poller: Poller(), initialCacheContents: #"{"body":{"moo":"bar"},"keyId":"fooKey"}"#.data(using: .utf8))
                 let fallback = "not found"
 
                 let value = configCache.getString("foo", fallback)
@@ -120,7 +120,7 @@ class ConfigCacheSpec: QuickSpec {
             let fetcher = Fetcher(client: APIClient(), environment: Environment())
 
             it("returns the value from config when key exists") {
-                let configCache = ConfigCache(fetcher: fetcher, poller: Poller(), initialCacheContents: ["foo": "true"])
+                let configCache = ConfigCache(fetcher: fetcher, poller: Poller(), initialCacheContents: #"{"body":{"foo":"true"},"keyId":"fooKey"}"#.data(using: .utf8))
 
                 let value = configCache.getBoolean("foo", false)
 
@@ -129,7 +129,7 @@ class ConfigCacheSpec: QuickSpec {
 
             it("returns the fallback when key is not found in config") {
                 let fetcher = Fetcher(client: APIClient(), environment: Environment())
-                let configCache = ConfigCache(fetcher: fetcher, poller: Poller(), initialCacheContents: ["moo": "true"])
+                let configCache = ConfigCache(fetcher: fetcher, poller: Poller(), initialCacheContents: #"{"body":{"moo":"true"},"keyId":"fooKey"}"#.data(using: .utf8))
                 let fallback = false
 
                 let value = configCache.getBoolean("foo", fallback)
@@ -151,7 +151,7 @@ class ConfigCacheSpec: QuickSpec {
             let fetcher = Fetcher(client: APIClient(), environment: Environment())
 
             it("returns value that can be treated as int from config") {
-                let configCache = ConfigCache(fetcher: fetcher, poller: Poller(), initialCacheContents: ["foo": "10"])
+                let configCache = ConfigCache(fetcher: fetcher, poller: Poller(), initialCacheContents: #"{"body":{"foo":"10"},"keyId":"fooKey"}"#.data(using: .utf8))
 
                 let value = configCache.getNumber("foo", 5)
 
@@ -159,7 +159,7 @@ class ConfigCacheSpec: QuickSpec {
             }
 
             it("returns value that can be treated as double from config") {
-                let configCache = ConfigCache(fetcher: fetcher, poller: Poller(), initialCacheContents: ["foo": "10.123"])
+                let configCache = ConfigCache(fetcher: fetcher, poller: Poller(), initialCacheContents: #"{"body":{"foo":"10.123"},"keyId":"fooKey"}"#.data(using: .utf8))
 
                 let value = configCache.getNumber("foo", 5.0)
 
@@ -167,7 +167,7 @@ class ConfigCacheSpec: QuickSpec {
             }
 
             it("returns value that can be treated as float from config") {
-                let configCache = ConfigCache(fetcher: fetcher, poller: Poller(), initialCacheContents: ["foo": "10.123"])
+                let configCache = ConfigCache(fetcher: fetcher, poller: Poller(), initialCacheContents: #"{"body":{"foo":"10.123"},"keyId":"fooKey"}"#.data(using: .utf8))
 
                 let value = configCache.getNumber("foo", 5.5)
 
@@ -175,7 +175,7 @@ class ConfigCacheSpec: QuickSpec {
             }
 
             it("returns value that can be treated as uint8 (byte) from config") {
-                let configCache = ConfigCache(fetcher: fetcher, poller: Poller(), initialCacheContents: ["foo": "254"])
+                let configCache = ConfigCache(fetcher: fetcher, poller: Poller(), initialCacheContents: #"{"body":{"foo":"254"},"keyId":"fooKey"}"#.data(using: .utf8))
 
                 let value = configCache.getNumber("foo", 10)
 
@@ -183,7 +183,7 @@ class ConfigCacheSpec: QuickSpec {
             }
 
             it("returns fallback when value string cannot be converted to a number") {
-                let configCache = ConfigCache(fetcher: fetcher, poller: Poller(), initialCacheContents: ["foo": "bar"])
+                let configCache = ConfigCache(fetcher: fetcher, poller: Poller(), initialCacheContents: #"{"body":{"foo":"bar"},"keyId":"fooKey"}"#.data(using: .utf8))
 
                 let value = configCache.getNumber("foo", 5)
 
@@ -191,7 +191,7 @@ class ConfigCacheSpec: QuickSpec {
             }
 
             it("returns fallback when key is not found in config") {
-                let configCache = ConfigCache(fetcher: fetcher, poller: Poller(), initialCacheContents: ["moo": "10"])
+                let configCache = ConfigCache(fetcher: fetcher, poller: Poller(), initialCacheContents: #"{"body":{"moo":"10"},"keyId":"fooKey"}"#.data(using: .utf8))
 
                 let value = configCache.getNumber("foo", 5)
 
@@ -218,7 +218,7 @@ class ConfigCacheSpec: QuickSpec {
             }
 
             it("returns dictionary contents when config is non-empty") {
-                let configCache = ConfigCache(fetcher: fetcher, poller: Poller(), initialCacheContents: ["moo": "10", "foo": "coo"])
+                let configCache = ConfigCache(fetcher: fetcher, poller: Poller(), initialCacheContents: #"{"body":{"moo":"10","foo":"coo"},"keyId":"fooKey"}"#.data(using: .utf8))
 
                 let value = configCache.getConfig()
 
@@ -226,7 +226,7 @@ class ConfigCacheSpec: QuickSpec {
             }
         }
         describe("refreshFromRemote function") {
-            let jsonData = (try? JSONSerialization.data(withJSONObject: ["body": ["foo": "bar"], "keyId": "aKey"], options: []))!
+            let jsonData = #"{"body":{"foo":"bar"},"keyId":"aKey"}"#.data(using: .utf8)!
             let fetcher = FetcherMock(client: APIClient(), environment: Environment())
             let configCache = ConfigCache(fetcher: fetcher, poller: Poller())
             let url = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask)[0].appendingPathComponent("bar")
@@ -303,7 +303,7 @@ class ConfigCacheSpec: QuickSpec {
                 }
 
                 it("adds the key after fetching it") {
-                    let jsonData = (try? JSONSerialization.data(withJSONObject: ["id": "aKey", "key": "123", "createdAt": ""], options: []))!
+                    let jsonData = #"{"id":"aKey","key":"123","createdAt":""}"#.data(using: .utf8)!
                     fetcher.fetchedKey = KeyModel(data: jsonData)
 
                     configCache.refreshFromRemote()

--- a/Tests/Unit/ConfigModelTests.swift
+++ b/Tests/Unit/ConfigModelTests.swift
@@ -6,9 +6,7 @@ class ConfigModelSpec: QuickSpec {
     override func spec() {
         context("initialization") {
             describe("when json is the expected format") {
-                let data = """
-                    {"body":{"key1":"val1","key2":"val2","key3":"val3"},"keyId":"a1b2c3"}
-                    """.data(using: .utf8) ?? Data()
+                let data = #"{"body":{"key1":"val1","key2":"val2","key3":"val3"},"keyId":"a1b2c3"}"#.data(using: .utf8) ?? Data()
                 let config = ConfigModel(data: data)
 
                 it("stores the original data in the jsonData property") {
@@ -35,9 +33,7 @@ class ConfigModelSpec: QuickSpec {
                 }
 
                 it("returns nil when json does not have a body object") {
-                    let dataString = """
-                    "key1":"val1","key2":"val2","key3":"val3","keyId":"a1b2c3"
-                    """
+                    let dataString = #""key1":"val1","key2":"val2","key3":"val3","keyId":"a1b2c3""#
                     let config = ConfigModel(data: dataString.data(using: .utf8) ?? Data())
 
                     expect(config).to(beNil())
@@ -50,9 +46,7 @@ class ConfigModelSpec: QuickSpec {
 
                     """.data(using: .utf8) ?? Data()
                     let config = ConfigModel(data: dataWithNewline)
-                    let dataWithoutNewline = """
-                    {"body":{"key1":"val1","key2":"val2","key3":"val3"},"keyId":"a1b2c3"}
-                    """.data(using: .utf8)
+                    let dataWithoutNewline = #"{"body":{"key1":"val1","key2":"val2","key3":"val3"},"keyId":"a1b2c3"}"#.data(using: .utf8)
 
                     expect(config?.jsonData).to(equal(dataWithoutNewline))
                 }

--- a/Tests/Unit/FetcherTests.swift
+++ b/Tests/Unit/FetcherTests.swift
@@ -145,12 +145,11 @@ class FetcherSpec: QuickSpec {
             }
 
             context("when valid config model is received as the result from the api client") {
+                let dataString = #"{"body":{"foo":"bar"},"keyId":"fooKey"}"#
+
                 it("will set the config dictionary in the result passed to the completion handler") {
                     var testResult: Any?
                     let apiClientMock = APIClientMock()
-                    let dataString = """
-                        {"body":{"foo":"bar"}}
-                        """
                     apiClientMock.data = dataString.data(using: .utf8)
                     let fetcher = Fetcher(client: apiClientMock, environment: Environment())
 
@@ -164,9 +163,6 @@ class FetcherSpec: QuickSpec {
                 it("will set the signature in the result passed to the completion handler") {
                     var testResult: Any?
                     let apiClientMock = APIClientMock()
-                    let dataString = """
-                        {"body":{"foo":"bar"}}
-                        """
                     apiClientMock.data = dataString.data(using: .utf8)
                     apiClientMock.headers = ["Signature": "a-sig"]
                     let fetcher = Fetcher(client: apiClientMock, environment: Environment())
@@ -182,9 +178,6 @@ class FetcherSpec: QuickSpec {
                     UserDefaults.standard.removeObject(forKey: Environment.etagKey)
                     let apiClientMock = APIClientMock()
                     let env = Environment()
-                    let dataString = """
-                        {"body":{"foo":"bar"}}
-                        """
                     apiClientMock.data = dataString.data(using: .utf8)
                     apiClientMock.headers = ["Etag": "an-etag"]
                     let fetcher = Fetcher(client: apiClientMock, environment: env)

--- a/Tests/Unit/RealRemoteConfigTests.swift
+++ b/Tests/Unit/RealRemoteConfigTests.swift
@@ -6,28 +6,32 @@ class RealRemoteConfigSpec: QuickSpec {
     override func spec() {
         describe("getString function") {
             it("retrieves string from the cache for provided key") {
-                RealRemoteConfig.shared.cache = createCacheMock(initialContents: ["foo": "moo"])
+                let data = #"{"body":{"foo":"moo"},"keyId":"fooKey"}"#.data(using: .utf8)!
+                RealRemoteConfig.shared.cache = createCacheMock(initialContents: data)
 
                 expect(RealRemoteConfig.shared.getString("foo", "bar")).to(equal("moo"))
             }
         }
         describe("getBoolean function") {
             it("retrieves boolean from the cache for provided key") {
-                RealRemoteConfig.shared.cache = createCacheMock(initialContents: ["foo": "true"])
+                let data = #"{"body":{"foo":"true"},"keyId":"fooKey"}"#.data(using: .utf8)!
+                RealRemoteConfig.shared.cache = createCacheMock(initialContents: data)
 
                 expect(RealRemoteConfig.shared.getBoolean("foo", false)).to(beTrue())
             }
         }
         describe("getNumber function") {
             it("retrieves number from the cache for provided key") {
-                RealRemoteConfig.shared.cache = createCacheMock(initialContents: ["foo": "10"])
+                let data = #"{"body":{"foo":"10"},"keyId":"fooKey"}"#.data(using: .utf8)!
+                RealRemoteConfig.shared.cache = createCacheMock(initialContents: data)
 
                 expect(RealRemoteConfig.shared.getNumber("foo", 20)).to(equal(10))
             }
         }
         describe("getConfig function") {
             it("returns the config cache dictionary") {
-                RealRemoteConfig.shared.cache = createCacheMock(initialContents: ["foo": "bar", "moo": "100"])
+                let data = #"{"body":{"foo":"bar","moo":"100"},"keyId":"fooKey"}"#.data(using: .utf8)!
+                RealRemoteConfig.shared.cache = createCacheMock(initialContents: data)
 
                 expect(RealRemoteConfig.shared.getConfig()).to(equal(["foo": "bar", "moo": "100"]))
             }

--- a/Tests/Unit/TestHelpers.swift
+++ b/Tests/Unit/TestHelpers.swift
@@ -110,16 +110,16 @@ class APIClientMock: APIClient {
     override func send<T>(request: URLRequest, parser: T.Type, completionHandler: @escaping (Result<Response, Error>) -> Void) where T: Parsable {
         self.request = request
 
-        guard let data = data else {
+        guard let data = data, let url = request.url else {
             return completionHandler(.failure(error ?? NSError(domain: "Test", code: 0, userInfo: nil)))
         }
-        if let httpResponse = HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: "1.1", headerFields: headers),
+        if let httpResponse = HTTPURLResponse(url: url, statusCode: 200, httpVersion: "1.1", headerFields: headers),
             let object = parser.init(data: data) {
             return completionHandler(.success(Response(object, httpResponse)))
         }
     }
 }
 
-func createCacheMock(initialContents: [String: Any] = ["body": ["": ""]]) -> CacheMock {
+func createCacheMock(initialContents: Data? = #"{"body":{"":""},"keyId":"fooKey"}"#.data(using: .utf8)) -> CacheMock {
     return CacheMock(fetcher: Fetcher(client: APIClient(), environment: Environment()), poller: Poller(), initialCacheContents: initialContents)
 }


### PR DESCRIPTION
# Description
- use guards instead of optional unwrapping in the models
- use Data for the initial cache contents
- update tests
- address comments from PR#18

## Links
SDKCF-1463

# Checklist
- [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [x] I wrote/updated tests for new/changed code
- [x] I ran `fastlane ci` without errors
