### PR TITLE
fix: travis CI can take a long time to run pod install so insert wait

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ before_install:
 - pod repo update
 
 script:
-- fastlane ci
+- travis_wait fastlane ci
 - bundle exec danger
 
 after_success:

--- a/Podfile
+++ b/Podfile
@@ -1,5 +1,3 @@
-source 'https://github.com/CocoaPods/Specs.git'
-
 platform :ios, '10.0'
 use_frameworks!
 


### PR DESCRIPTION
Travis CI can take a long time to run pod install so insert wait before fastlane command, also remove explicit Podfile GitHub source URL so that default CDN source will be used

## Links
SDKCF-2123

# Checklist
- [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [ ] I wrote/updated tests for new/changed code
- [ ] I ran `fastlane ci` without errors
