### PR TITLE
build: remove bundle install command from Travis CI config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,5 +24,8 @@ Pods
 # Jazzy-generated documentation
 docs/
 
+# Gems
+.bundle/
+vendor/
 # Use latest gem versions
 Gemfile.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,9 @@
 language: swift
 xcode_workspace: RRemoteConfig.xcworkspace
 xcode_scheme: Tests
-osx_image: xcode10.2
+osx_image: xcode11.3
 
 before_install:
-- bundle install
-- gem update fastlane cocoapods --no-document
 - pod repo update
 
 script:

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,6 @@
 source 'https://rubygems.org'
 
+gem "fastlane"
 gem "cocoapods"
 gem "xcov"
 gem "jazzy"

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,7 +1,7 @@
 PODS:
   - Nimble (8.0.1)
   - Quick (2.1.0)
-  - RRemoteConfig (0.0.1)
+  - RRemoteConfig (1.0.0)
 
 DEPENDENCIES:
   - Nimble
@@ -9,7 +9,7 @@ DEPENDENCIES:
   - RRemoteConfig (from `./RRemoteConfig.podspec`)
 
 SPEC REPOS:
-  https://github.com/cocoapods/specs.git:
+  trunk:
     - Nimble
     - Quick
 
@@ -20,8 +20,8 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   Nimble: 45f786ae66faa9a709624227fae502db55a8bdd0
   Quick: 4be43f6634acfa727dd106bdf3929ce125ffa79d
-  RRemoteConfig: b66577f1993fc685627593fdcc315ef67b38a6be
+  RRemoteConfig: 1ac19c32c349550cc262e2a98d0144b9d876aea6
 
-PODFILE CHECKSUM: 1046c0078aa49254b1d3f058652b15ce93dcda12
+PODFILE CHECKSUM: 97f8a2d394861924b0c7524397cd0674e52a07fe
 
-COCOAPODS: 1.7.5
+COCOAPODS: 1.9.1

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -6,8 +6,6 @@ default_platform(:ios)
 platform :ios do
   desc "Build everything"
   lane :ci do |options|
-    xcversion(version: "~> 10.2")
-
     swiftlint(
       strict: true,
       ignore_exit_status: false


### PR DESCRIPTION
# Description
- travis runs bundle install by default so remove explicit bundle install from before_install in yml config
- handle fastlane gem install in Gemfile
- use latest xcode image for CI

# Checklist
- [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [ ] I wrote/updated tests for new/changed code
- [x] I ran `fastlane ci` without errors
