### PR TITLE
fix: Use the device's preferred languages to determine the language c…

### DIFF
--- a/RRemoteConfig/Bundle+Environment.swift
+++ b/RRemoteConfig/Bundle+Environment.swift
@@ -26,7 +26,12 @@ extension Bundle: EnvironmentSetupProtocol {
     }
 
     func languageCode() -> String? {
-        return Locale.current.languageCode
+        // Use the device's preferred languages rather than Locale.current
+        // because 'current' depends on the languages an app has been localized into
+        guard let language = Locale.preferredLanguages.first else {
+            return Locale.current.languageCode
+        }
+        return Locale(identifier: language).languageCode
     }
 
     func countryCode() -> String? {


### PR DESCRIPTION
# Description
Use the device's preferred languages to determine the language code rather than Locale.current because 'current' depends on the languages an app has been localized into

## Links
SDKCF-1792

# Checklist
- [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [x] I wrote/updated tests for new/changed code
- [x] I ran `fastlane ci` without errors
