### PR TITLE
improve: make polling delay configurable from plist at build time

### DIFF
--- a/RRemoteConfig/Bundle+Environment.swift
+++ b/RRemoteConfig/Bundle+Environment.swift
@@ -37,4 +37,11 @@ extension Bundle: EnvironmentSetupProtocol {
     func countryCode() -> String? {
         return Locale.current.regionCode
     }
+
+    func pollingDelay() -> TimeInterval? {
+        guard let number = self.object(forInfoDictionaryKey: "RRCConfigFetchPollingDelayInSeconds") as? NSNumber else {
+            return nil
+        }
+        return TimeInterval(truncating: number)
+    }
 }

--- a/RRemoteConfig/Environment.swift
+++ b/RRemoteConfig/Environment.swift
@@ -7,6 +7,7 @@ internal protocol EnvironmentSetupProtocol {
     func sdkVersion() -> String
     func languageCode() -> String?
     func countryCode() -> String?
+    func pollingDelay() -> TimeInterval?
 }
 
 internal class Environment {
@@ -52,6 +53,9 @@ internal class Environment {
     }
     var appVersion: String {
         return bundle.value(for: "CFBundleShortVersionString" as String) ?? bundle.valueNotFound
+    }
+    var pollingDelay: TimeInterval? {
+        return bundle.pollingDelay()
     }
     var deviceModel: String {
         return bundle.deviceModel()

--- a/RRemoteConfig/Poller.swift
+++ b/RRemoteConfig/Poller.swift
@@ -8,13 +8,18 @@ extension RunLoop: PollerRunLoopProtocol {
     }
 }
 
+internal enum PollerConstants {
+    static let defaultDelay: TimeInterval = 60.0 * 60.0
+    static let minimumDelay: TimeInterval = 60.0
+}
+
 internal class Poller {
     private let delay: TimeInterval
     private var runLoop: PollerRunLoopProtocol?
     private var timer: Timer?
 
-    init(delay: TimeInterval = 60.0 * 60.0, runLoop: PollerRunLoopProtocol = RunLoop.current) {
-        self.delay = delay
+    init(delay: TimeInterval = PollerConstants.defaultDelay, runLoop: PollerRunLoopProtocol = RunLoop.current) {
+        self.delay = delay < PollerConstants.minimumDelay ? PollerConstants.minimumDelay : delay
         self.runLoop = runLoop
     }
 

--- a/RRemoteConfig/Poller.swift
+++ b/RRemoteConfig/Poller.swift
@@ -19,7 +19,7 @@ internal class Poller {
     private var timer: Timer?
 
     init(delay: TimeInterval = PollerConstants.defaultDelay, runLoop: PollerRunLoopProtocol = RunLoop.current) {
-        self.delay = delay < PollerConstants.minimumDelay ? PollerConstants.minimumDelay : delay
+        self.delay = max(PollerConstants.minimumDelay, delay)
         self.runLoop = runLoop
     }
 

--- a/RRemoteConfig/RealRemoteConfig.swift
+++ b/RRemoteConfig/RealRemoteConfig.swift
@@ -8,9 +8,9 @@ internal class RealRemoteConfig {
 
     init() {
         self.environment = Environment()
-        self.poller = Poller()
         self.apiClient = APIClient()
         self.fetcher = Fetcher(client: apiClient, environment: environment)
+        self.poller = Poller(delay: environment.pollingDelay ?? PollerConstants.defaultDelay)
         self.cache = ConfigCache(fetcher: fetcher, poller: poller)
     }
 

--- a/Tests/Functional/FunctionalTests.swift
+++ b/Tests/Functional/FunctionalTests.swift
@@ -15,13 +15,13 @@ class FunctionalSpec: QuickSpec {
 
             it("asynchronously executes the action after the specified delay") {
                 var actionCalled = 0
-                let poller = Poller(delay: PollerConstants.minimumDelay) // 60s
+                let poller = Poller(delay: PollerConstants.minimumDelay)
 
                 poller.start {
                     actionCalled += 1
                 }
 
-                expect(actionCalled).toEventually(beGreaterThanOrEqualTo(2), timeout: 70)
+                expect(actionCalled).toEventually(beGreaterThan(1), timeout: PollerConstants.minimumDelay + 10)
             }
         }
     }

--- a/Tests/Functional/FunctionalTests.swift
+++ b/Tests/Functional/FunctionalTests.swift
@@ -1,25 +1,28 @@
-import XCTest
+import Quick
+import Nimble
+@testable import RRemoteConfig
 
-class FunctionalTests: XCTestCase {
+class FunctionalSpec: QuickSpec {
+    override func spec() {
+        describe("start function") {
+            class MockRunLoop: PollerRunLoopProtocol {
+                var addedTimer: Timer?
 
-    override func setUp() {
-        // Put setup code here. This method is called before the invocation of each test method in the class.
-    }
+                func addTimer(_ timer: Timer) {
+                    self.addedTimer = timer
+                }
+            }
 
-    override func tearDown() {
-        // Put teardown code here. This method is called after the invocation of each test method in the class.
-    }
+            it("asynchronously executes the action after the specified delay") {
+                var actionCalled = 0
+                let poller = Poller(delay: PollerConstants.minimumDelay) // 60s
 
-    func testExample() {
-        // This is an example of a functional test case.
-        // Use XCTAssert and related functions to verify your tests produce the correct results.
-    }
+                poller.start {
+                    actionCalled += 1
+                }
 
-    func testPerformanceExample() {
-        // This is an example of a performance test case.
-        self.measure {
-            // Put the code you want to measure the time of here.
+                expect(actionCalled).toEventually(beGreaterThanOrEqualTo(2), timeout: 70)
+            }
         }
     }
-
 }

--- a/Tests/Unit/EnvironmentTests.swift
+++ b/Tests/Unit/EnvironmentTests.swift
@@ -71,15 +71,6 @@ class EnvironmentSpec: QuickSpec {
                 expect(environment.appVersion).to(equal("foo"))
             }
 
-            it("has the expected subscription key") {
-                let mockBundle = BundleMock()
-                mockBundle.mockSubKey = "foo"
-
-                let environment = Environment(bundle: mockBundle)
-
-                expect(environment.subscriptionKey).to(contain("foo"))
-            }
-
             it("has the expected OS version") {
                 let mockBundle = BundleMock()
                 mockBundle.mockOsVersion = "foo"
@@ -132,6 +123,15 @@ class EnvironmentSpec: QuickSpec {
                 let environment = Environment(bundle: mockBundle)
 
                 expect(environment.countryCode).to(equal("foo"))
+            }
+
+            it("has the expected polling delay value") {
+                let mockBundle = BundleMock()
+                mockBundle.mockDelay = 10.12345
+
+                let environment = Environment(bundle: mockBundle)
+
+                expect(environment.pollingDelay).to(equal(10.12345))
             }
         }
         context("when bundle does not have valid key values") {
@@ -186,6 +186,10 @@ class EnvironmentSpec: QuickSpec {
 
             it("will return the 'not found' value when country code can't be read") {
                 expect(environment.countryCode).to(equal(mockBundleInvalid.valueNotFound))
+            }
+
+            it("will return nil when the polling delay can't be read") {
+                expect(environment.pollingDelay).to(beNil())
             }
         }
     }

--- a/Tests/Unit/PollerTests.swift
+++ b/Tests/Unit/PollerTests.swift
@@ -12,22 +12,40 @@ class PollerSpec: QuickSpec {
                     self.addedTimer = timer
                 }
             }
-            it("creates a timer with time interval equal to default delay of 1 hour") {
+            it("creates a timer with time interval equal to default delay when no explicit delay param is passed into initializer") {
                 let runLoop: MockRunLoop = MockRunLoop()
                 let poller = Poller(runLoop: runLoop)
 
                 poller.start { }
 
-                expect(runLoop.addedTimer?.timeInterval).toEventually(equal(3600.0))
+                expect(runLoop.addedTimer?.timeInterval).toEventually(equal(PollerConstants.defaultDelay))
             }
 
-            it("creates a timer with time interval equal to delay param") {
+            it("creates a timer with time interval equal to passed in delay param when param value is greater than minimum delay") {
                 let runLoop: MockRunLoop = MockRunLoop()
-                let poller = Poller(delay: 10.5, runLoop: runLoop)
+                let poller = Poller(delay: 100.5, runLoop: runLoop)
 
                 poller.start { }
 
-                expect(runLoop.addedTimer?.timeInterval).toEventually(equal(10.5))
+                expect(runLoop.addedTimer?.timeInterval).toEventually(equal(100.5))
+            }
+
+            it("creates a timer with time interval equal to minimum delay if passed in delay param is zero") {
+                let runLoop: MockRunLoop = MockRunLoop()
+                let poller = Poller(delay: 0, runLoop: runLoop)
+
+                poller.start { }
+
+                expect(runLoop.addedTimer?.timeInterval).toEventually(equal(PollerConstants.minimumDelay))
+            }
+
+            it("creates a timer with time interval equal to minimum delay if passed in delay param is less than minimum delay") {
+                let runLoop: MockRunLoop = MockRunLoop()
+                let poller = Poller(delay: 10, runLoop: runLoop)
+
+                poller.start { }
+
+                expect(runLoop.addedTimer?.timeInterval).toEventually(equal(PollerConstants.minimumDelay))
             }
 
             it("synchronously executes action closure exactly once") {
@@ -39,17 +57,6 @@ class PollerSpec: QuickSpec {
                 }
 
                 expect(actionCalled).to(equal(1))
-            }
-
-            it("asynchronously executes the action after the specified delay") {
-                var actionCalled = 0
-                let poller = Poller(delay: 0.5)
-
-                poller.start {
-                    actionCalled += 1
-                }
-
-                expect(actionCalled).toEventually(beGreaterThan(2), timeout: 2)
             }
         }
     }

--- a/Tests/Unit/TestHelpers.swift
+++ b/Tests/Unit/TestHelpers.swift
@@ -1,6 +1,7 @@
 @testable import RRemoteConfig
 
 class BundleMock: EnvironmentSetupProtocol {
+
     var mockAppId: String?
     var mockAppName: String?
     var mockAppVersion: String?
@@ -13,6 +14,7 @@ class BundleMock: EnvironmentSetupProtocol {
     var mockLanguageCode: String?
     var mockCountryCode: String?
     var mockNotFound: String?
+    var mockDelay: TimeInterval?
 
     func value(for key: String) -> String? {
         switch key {
@@ -63,6 +65,10 @@ class BundleMock: EnvironmentSetupProtocol {
 
     func countryCode() -> String? {
         return mockCountryCode ?? valueNotFound
+    }
+
+    func pollingDelay() -> TimeInterval? {
+        return mockDelay
     }
 }
 


### PR DESCRIPTION
# Description
Make polling delay configurable from plist at build time

## Links
SDKCF-2458

# Checklist
- [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [x] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `fastlane ci` without errors
