### PR TITLE
improve: add API to fetch config and apply directly SDKCF-2483

### DIFF
--- a/RRemoteConfig/Bundle+Environment.swift
+++ b/RRemoteConfig/Bundle+Environment.swift
@@ -44,4 +44,11 @@ extension Bundle: EnvironmentSetupProtocol {
         }
         return TimeInterval(truncating: number)
     }
+
+    func applyConfigDirectlyAfterFetch() -> Bool {
+        guard let applyDirectly = self.object(forInfoDictionaryKey: "RRCApplyConfigDirectlyAfterFetch") as? Bool else {
+            return false // not found in plist
+        }
+        return applyDirectly
+    }
 }

--- a/RRemoteConfig/Environment.swift
+++ b/RRemoteConfig/Environment.swift
@@ -8,6 +8,7 @@ internal protocol EnvironmentSetupProtocol {
     func languageCode() -> String?
     func countryCode() -> String?
     func pollingDelay() -> TimeInterval?
+    func applyConfigDirectlyAfterFetch() -> Bool
 }
 
 internal class Environment {
@@ -53,6 +54,9 @@ internal class Environment {
     }
     var appVersion: String {
         return bundle.value(for: "CFBundleShortVersionString" as String) ?? bundle.valueNotFound
+    }
+    var applyConfigDirectlyAfterFetch: Bool {
+        return bundle.applyConfigDirectlyAfterFetch()
     }
     var pollingDelay: TimeInterval? {
         return bundle.pollingDelay()

--- a/RRemoteConfig/Loader.swift
+++ b/RRemoteConfig/Loader.swift
@@ -5,6 +5,6 @@ import Foundation
 // method.
 public class Loader: NSObject {
     @objc public static func loadRemoteConfig() {
-        RealRemoteConfig.shared.refreshConfig()
+        RealRemoteConfig.shared.fetchAndPollConfig()
     }
 }

--- a/RRemoteConfig/Models.swift
+++ b/RRemoteConfig/Models.swift
@@ -2,7 +2,7 @@ protocol Parsable {
     init?(data: Data)
 }
 
-typealias ConfigDictionary = [String: String]
+public typealias ConfigDictionary = [String: String]
 
 internal struct ConfigModel: Parsable {
     let jsonData: Data

--- a/RRemoteConfig/RealRemoteConfig.swift
+++ b/RRemoteConfig/RealRemoteConfig.swift
@@ -9,9 +9,12 @@ internal class RealRemoteConfig {
     init() {
         self.environment = Environment()
         self.apiClient = APIClient()
-        self.fetcher = Fetcher(client: apiClient, environment: environment)
+        self.fetcher = Fetcher(client: apiClient,
+                               environment: environment)
         self.poller = Poller(delay: environment.pollingDelay ?? PollerConstants.defaultDelay)
-        self.cache = ConfigCache(fetcher: fetcher, poller: poller)
+        self.cache = ConfigCache(fetcher: fetcher,
+                                 poller: poller,
+                                 applyConfigDirectly: environment.applyConfigDirectlyAfterFetch)
     }
 
     func getString(_ key: String, _ fallback: String) -> String {
@@ -30,7 +33,11 @@ internal class RealRemoteConfig {
         return cache.getConfig()
     }
 
-    func refreshConfig() {
-        cache.refreshFromRemote()
+    func fetchAndPollConfig() {
+        cache.fetchAndPollConfig()
+    }
+
+    func fetchAndApplyConfig(completionHandler: @escaping (ConfigDictionary) -> Void) {
+        cache.fetchAndApplyConfig(completionHandler: completionHandler)
     }
 }

--- a/RRemoteConfig/RemoteConfig.swift
+++ b/RRemoteConfig/RemoteConfig.swift
@@ -42,4 +42,12 @@
     @objc public class func getConfig() -> [String: String] {
         return RealRemoteConfig.shared.getConfig()
     }
+
+    /// Manually trigger a fetch of config values.
+    /// **Note:** Config values are applied directly after fetch.
+    ///
+    /// - Parameter completionHandler: Completion handler that returns the fetched config values as a dictionary
+    @objc public class func fetchAndApplyConfig(completionHandler: @escaping (ConfigDictionary) -> Void) {
+        RealRemoteConfig.shared.fetchAndApplyConfig(completionHandler: completionHandler)
+    }
 }

--- a/Tests/Unit/ConfigCacheTests.swift
+++ b/Tests/Unit/ConfigCacheTests.swift
@@ -2,6 +2,8 @@ import Quick
 import Nimble
 @testable import RRemoteConfig
 
+// swiftlint:disable file_length
+
 class ConfigCacheSpec: QuickSpec {
     override func spec() {
         describe("init function") {

--- a/Tests/Unit/EnvironmentTests.swift
+++ b/Tests/Unit/EnvironmentTests.swift
@@ -133,6 +133,15 @@ class EnvironmentSpec: QuickSpec {
 
                 expect(environment.pollingDelay).to(equal(10.12345))
             }
+
+            it("has the expected 'apply config directly' value") {
+                let mockBundle = BundleMock()
+                mockBundle.mockApplyConfigDirectly = true
+
+                let environment = Environment(bundle: mockBundle)
+
+                expect(environment.applyConfigDirectlyAfterFetch).to(equal(true))
+            }
         }
         context("when bundle does not have valid key values") {
             let mockBundleInvalid = BundleMock()
@@ -190,6 +199,10 @@ class EnvironmentSpec: QuickSpec {
 
             it("will return nil when the polling delay can't be read") {
                 expect(environment.pollingDelay).to(beNil())
+            }
+
+            it("will return false when the 'apply directly' value can't be read") {
+                expect(environment.applyConfigDirectlyAfterFetch).to(beFalse())
             }
         }
     }

--- a/Tests/Unit/RealRemoteConfigTests.swift
+++ b/Tests/Unit/RealRemoteConfigTests.swift
@@ -51,7 +51,7 @@ class RealRemoteConfigSpec: QuickSpec {
                 RealRemoteConfig.shared.cache = createCacheMock()
                 (RealRemoteConfig.shared.cache as? CacheMock)?.fetchCalled = false
 
-                RealRemoteConfig.shared.fetchAndApplyConfig(completionHandler: { _ in } )
+                RealRemoteConfig.shared.fetchAndApplyConfig(completionHandler: { _ in })
 
                 expect((RealRemoteConfig.shared.cache as? CacheMock)?.fetchCalled).to(equal(true))
             }

--- a/Tests/Unit/RealRemoteConfigTests.swift
+++ b/Tests/Unit/RealRemoteConfigTests.swift
@@ -36,14 +36,24 @@ class RealRemoteConfigSpec: QuickSpec {
                 expect(RealRemoteConfig.shared.getConfig()).to(equal(["foo": "bar", "moo": "100"]))
             }
         }
-        describe("refreshConfig function") {
-            it("calls config cache refresh") {
+        describe("fetchAndPollConfig function") {
+            it("calls config cache fetch") {
                 RealRemoteConfig.shared.cache = createCacheMock()
-                (RealRemoteConfig.shared.cache as? CacheMock)?.refreshCalled = false
+                (RealRemoteConfig.shared.cache as? CacheMock)?.fetchCalled = false
 
-                RealRemoteConfig.shared.refreshConfig()
+                RealRemoteConfig.shared.fetchAndPollConfig()
 
-                expect((RealRemoteConfig.shared.cache as? CacheMock)?.refreshCalled).to(equal(true))
+                expect((RealRemoteConfig.shared.cache as? CacheMock)?.fetchCalled).to(equal(true))
+            }
+        }
+        describe("fetchAndApplyConfig function") {
+            it("calls config cache fetch") {
+                RealRemoteConfig.shared.cache = createCacheMock()
+                (RealRemoteConfig.shared.cache as? CacheMock)?.fetchCalled = false
+
+                RealRemoteConfig.shared.fetchAndApplyConfig(completionHandler: { _ in } )
+
+                expect((RealRemoteConfig.shared.cache as? CacheMock)?.fetchCalled).to(equal(true))
             }
         }
     }

--- a/Tests/Unit/TestHelpers.swift
+++ b/Tests/Unit/TestHelpers.swift
@@ -1,7 +1,6 @@
 @testable import RRemoteConfig
 
 class BundleMock: EnvironmentSetupProtocol {
-
     var mockAppId: String?
     var mockAppName: String?
     var mockAppVersion: String?
@@ -15,6 +14,7 @@ class BundleMock: EnvironmentSetupProtocol {
     var mockCountryCode: String?
     var mockNotFound: String?
     var mockDelay: TimeInterval?
+    var mockApplyConfigDirectly = false
 
     func value(for key: String) -> String? {
         switch key {
@@ -70,13 +70,21 @@ class BundleMock: EnvironmentSetupProtocol {
     func pollingDelay() -> TimeInterval? {
         return mockDelay
     }
+
+    func applyConfigDirectlyAfterFetch() -> Bool {
+        return mockApplyConfigDirectly
+    }
 }
 
 class CacheMock: ConfigCache {
-    var refreshCalled = false
+    var fetchCalled = false
 
-    override func refreshFromRemote() {
-        self.refreshCalled = true
+    override func fetchAndPollConfig() {
+        self.fetchCalled = true
+    }
+
+    override func fetchAndApplyConfig(completionHandler: @escaping (ConfigDictionary) -> Void) {
+        self.fetchCalled = true
     }
 }
 


### PR DESCRIPTION
# Description
Add API to fetch config and apply directly and a plist option for config to always be applied directly after fetch.

## Links
SDKCF-2483

# Checklist
- [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [x] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data before every commit, including API endpoints and keys
- [x] I ran `fastlane ci` without errors
